### PR TITLE
chore: bump version to 1.1.9

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "fling-downloader",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "FLiNG Downloader - Game Modifier Download Integration Tool",
   "homepage": "https://github.com/Sqhh99/FLiNG-Downloader",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## 关联

准备发布 v1.1.9。

## 改了什么

把 `vcpkg.json` 的版本从 `1.1.8` 改为 `1.1.9`。合入后会打 `v1.1.9` tag 触发 `make-release.yml`。

## 怎么验证

- [x] 仅版本号变更
- [ ] 合入后确认 tag `v1.1.9` 触发 Make Release

## 检查项

- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
- [x] UI / QML 改动附了截图（不适用）
- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明（未改）
- [x] AI 使用披露：是（用于核对发版流程并起草版本号提交）