### PR TITLE
docs: 补全 CLAUDE.md 并归档一次网络/下载链路代码审查

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,144 @@
-AGENTS.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+FLiNG Downloader is a Windows-only Qt 6 / QML desktop app (C++17) that searches
+flingtrainer.com, downloads game trainers, and manages them locally. Chinese and
+Japanese game titles are resolved to the site's canonical English titles through a
+bundled SQLite translation database.
+
+See [AGENTS.md](AGENTS.md) for the repository map and coding conventions, and
+[CONTRIBUTING.md](CONTRIBUTING.md) for human-facing contribution rules.
+
+## Build & test
+
+Everything goes through `build.cmd` (a Windows batch script wrapping CMake presets +
+Ninja). It requires Visual Studio 2022, CMake ≥ 3.25, Ninja, Qt 6, vcpkg, `VCPKG_ROOT`,
+and `CMAKE_PREFIX_PATH` when Qt is not at the hard-coded default (`D:/Qt/6.10.0/msvc2022_64`).
+
+```bat
+build.cmd                  :: Release  -> build\ninja-release\
+build.cmd debug            :: Debug    -> build\ninja-debug\
+build.cmd run debug        :: build + launch
+build.cmd tests            :: configure -DFLING_BUILD_TESTS=ON, build, run via ctest
+build.cmd benchmark --filter CoverExtractor/.*
+build.cmd i18n             :: regenerate .ts + .qm
+build.cmd i18n check       :: verify translations are in sync (local check, not a CI gate)
+build.cmd rebuild / clean
+```
+
+**Working from WSL:** the batch script cannot run under bash. Invoke it through
+`cmd.exe /c` from the Windows path, e.g.
+`cmd.exe /c build.cmd tests`.
+Reading/editing sources from WSL is fine; only building and running need Windows.
+
+**Running a single test:** ctest registers one aggregate test, so filter at the GoogleTest
+level instead of through ctest:
+
+```bat
+"build\ninja-release\FLiNG Downloader Tests.exe" --gtest_filter=BackendTest.*
+```
+
+The test binary lands in the *root* of the build dir (`RUNTIME_OUTPUT_DIRECTORY`), next to
+the `onnxruntime.dll` and `models/` copied there by a POST_BUILD step — running it from
+elsewhere breaks `CoverExtractor`, which loads both via `applicationDirPath()`.
+
+## Architecture
+
+### Layering
+
+QML owns all presentation; C++ owns all logic. There is exactly one bridge object.
+
+- `src/main.cpp` — installs `Logger`, applies the saved language, initializes
+  `GameMappingManager`, constructs `Backend`, injects it into QML via
+  `engine.setInitialProperties({{"backend", ...}})`, and loads `qrc:/qml/Main.qml`.
+  `initialTheme` and a `Log` facade go in as context properties.
+- `src/Backend.{h,cpp}` — the single `QML_ELEMENT QML_SINGLETON` bridge. Every
+  `Q_PROPERTY` / `Q_INVOKABLE` QML touches lives here; it owns the two list models,
+  the download-task queue, and the update-manager instances. New user-visible features
+  almost always mean a new property/invokable here plus wiring into a manager.
+- `qml/` — `Main.qml` (frameless window) hosts `pages/` (SearchPage, DownloadedPage) built
+  from `components/`. `themes/ThemeProvider.qml` is a QML singleton holding all nine theme
+  palettes; C++ `ThemeManager` only persists the selected index, it does not style anything.
+
+The QML module is declared with `qt_add_qml_module` in the root `CMakeLists.txt` — new
+`.qml` files and resources must be added to its `QML_FILES` / `RESOURCES` lists or they
+won't exist at runtime.
+
+### Managers (all singletons, `getInstance()`)
+
+Business logic sits in independent, callback-driven singletons under `src/`; `Backend`
+orchestrates them and none of them know about QML.
+
+- `NetworkManager` — search, download, and update traffic all goes through
+  `sendGetRequest` / `downloadFile` / `downloadFileWithStatus`. The one exception is
+  `CoverExtractor`, which owns a private `QNetworkAccessManager` and calls `get()`
+  directly, so it bypasses the test hooks below.
+- `SearchManager` → `ModifierParser` (pugixml) — scrapes `flingtrainer.com/?s=` and the
+  homepage, parses HTML into `ModifierInfo`, sorts by relevance, and back-fills missing
+  option counts/game versions from detail pages.
+- `GameMappingManager` / `TranslationDatabase` — CN/JA → canonical English resolution.
+  `translateToEnglishForSearch()` deliberately only accepts exact and normalized-exact
+  matches so broad Latin queries stay site searches instead of collapsing to one title.
+- `DownloadManager` / `ModifierManager` / `FileSystem` — download queue, `.crdownload`
+  temp files, resume, archive/executable detection and renaming, downloaded-list persistence.
+- `AppUpdateManager` / `DatabaseUpdateManager` — GitHub or Gitee release checks (the
+  configured source is used *strictly*, with no cross-fallback) plus installer/DB download.
+- `ConfigManager` — `QSettings`-backed; theme, language, download path, update prefs.
+- `CoverExtractor` — downloads the trainer screenshot and crops the game cover with a
+  YOLO ONNX model via OpenCV + header-only YOLOs-CPP; runs off the GUI thread and caches
+  results on disk. The staleness guard for switching modifiers mid-flight is
+  `Backend::m_coverRequestId`, not part of `CoverExtractor` — new callers do not inherit it.
+- `Logger` — installs a Qt message handler; use the `LOG_DEBUG()/LOG_WARN()` macros in
+  C++ and `Log.debug(...)` in QML rather than `qDebug()`/`console.log()`.
+
+### Translation database
+
+`resources/fling_translations.db` ships with the app, and updates are written to an
+AppData override copy. `TranslationDatabase::resolveDatabasePath()` validates both
+(required: `metadata.release_tag` and the `games.english`, `games.normalized_english`,
+`games.chinese_simplified`, `games.japanese` columns; `metadata.schema_version` is
+optional but rejected when present and not `1`) and picks the newer valid `release_tag` — an override older than the bundled copy is ignored. Changing
+this schema means changing the separate `game-mappings-updater` release repo too.
+
+### Packaging
+
+Two executables: `FLiNG Downloader.exe` (the Qt app) and `FLiNG Launcher.exe`, a tiny
+`/MT`, Qt-free shim that starts `app\FLiNG Downloader.exe` — release layouts put the real
+app in an `app\` subdirectory behind the launcher.
+
+## Testing
+
+`tests/` is compiled from the same `TESTABLE_PROJECT_SOURCES` as the app (everything
+except `main.cpp`), so tests link the production singletons directly. New test files must
+be added to `TEST_SOURCES` in `tests/CMakeLists.txt`.
+
+Never hit the live network or the user's real settings from a test. `tests/fixtures/test_support.h`
+provides the seams — note they cover `NetworkManager` only, so a `CoverExtractor` test would
+still reach the real network through its private manager:
+
+- `ScopedNetworkHooks` — installs `NetworkManager::setGetRequestHandlerForTesting` /
+  `setDownloadRequestHandlerForTesting` and resets them on destruction.
+- `ScopedConfigState` — snapshots and restores `ConfigManager` state.
+- `createTranslationDatabase(...)` — builds throwaway SQLite fixtures, including a
+  deliberately malformed variant for schema-validation tests.
+
+`tests/unit/` holds isolated behavior, `tests/integration/` the network/database
+workflows, `tests/performance/` Google Benchmark cases (built separately with
+`-DFLING_BUILD_BENCHMARKS=ON`; only `CoverExtractor` is covered, over the sample images
+in `tests/resources/fling_trainer_screenshot/`).
+
+## Gotchas
+
+- The app version is derived from `git describe --tags` at configure time and injected as
+  `FLING_APP_VERSION`; override with `build.cmd release --app-version 1.2.3`. Pushing a
+  `v*` tag triggers the release workflow (a tag containing `-` becomes a GitHub pre-release).
+- vcpkg installs into `third_party/` (`VCPKG_INSTALLED_DIR`) with the
+  `x64-windows-static-md` triplet — static libs, dynamic CRT, to match Qt's prebuilt DLLs.
+  `third_party/YOLOs-CPP` is vendored; ONNX Runtime is fetched by `cmake/FetchONNXRuntime.cmake`.
+- User-facing strings need `qsTr()` in QML / `tr()` in C++, followed by `build.cmd i18n`
+  to regenerate `.ts`/`.qm`. `build.cmd i18n check` verifies they are in sync; CI
+  regenerates them before building and prints the diff for information only.
+- vcpkg port versions come from `vcpkg.json`'s `builtin-baseline` — do not `git pull` the
+  vcpkg clone to fix a dependency problem.
+- `agents/prompts/knowledge_base.md` is stale WebRTC boilerplate and does not apply here.

--- a/docs/code-reviews/2026-08-26-network-download-code-review.md
+++ b/docs/code-reviews/2026-08-26-network-download-code-review.md
@@ -1,0 +1,141 @@
+# Network & Download Path Code Review
+
+- **Date:** 2026-08-26
+- **Reviewed at commit:** `6ae1341` (main)
+- **Scope:** C++ correctness in `src/` — network, download queue, file handling, and
+  threading paths. Reviewed by reading the source and tracing call paths.
+- **Not covered:** the QML layer, regex robustness in `ModifierParser.cpp` against site
+  markup changes, and the test suite's own coverage.
+
+## Status summary
+
+**No finding in this document has been implemented.** The review produced no code changes;
+every item below is open. The only file modified in the session that produced this review
+was `CLAUDE.md` (documentation), not application code.
+
+| # | Finding | Severity | Implemented |
+|---|---------|----------|-------------|
+| 1 | Pause/cancel can abort the wrong download | Medium | ❌ No — open |
+| 2 | Remote-derived version text reaches the save path unsanitized | Medium | ❌ No — open |
+| 3 | `m_currentDownloadReply` is never initialized | Low–Medium (latent) | ❌ No — open |
+| 4 | `file->write()` result discarded, so short writes report success | Low | ❌ No — open |
+
+Suggested order if these get picked up: #1 and #2 first.
+
+---
+
+## 1. Pause/cancel can abort the wrong download
+
+**Location:** `src/NetworkManager.cpp:463` · **Severity:** Medium · **Implemented:** ❌ No
+
+`NetworkManager` tracks exactly one in-flight download in `m_currentDownloadReply`, but
+three independent features write to it:
+
+- modifier downloads — `src/DownloadManager.cpp:39`
+- app installer — `src/AppUpdateManager.cpp:69`
+- translation database — `src/DatabaseUpdateManager.cpp:73`
+
+Each `downloadFileWithStatus` call overwrites the member, and `cancelDownload()` aborts
+whichever reply was assigned last. `Backend::downloadAppUpdate()` (`src/Backend.cpp:692`)
+guards only on app-update state and does not check for an active modifier download, so the
+overlap is reachable:
+
+1. Start a modifier download → `m_currentDownloadReply` = modifier reply.
+2. Click "download update" → `m_currentDownloadReply` = installer reply.
+3. Click pause on the modifier → `Backend::pauseDownload` (`src/Backend.cpp:464`) →
+   `DownloadManager::cancelDownload()` → **aborts the installer**.
+
+The modifier download keeps running while the app update dies silently, and the task list
+still marks the modifier "paused".
+
+**Root cause:** a single shared reply handle for logically independent transfers.
+**Direction:** give each download its own handle, or key the abort by task id.
+
+## 2. Remote-derived version text reaches the save path unsanitized
+
+**Location:** `src/Backend.cpp:434` · **Severity:** Medium · **Implemented:** ❌ No
+
+`downloadModifier` sanitizes the modifier name — strips `\ / : * ? " < > |`, trims, removes
+trailing dots — then concatenates an unsanitized sibling value:
+
+```cpp
+const QString savePath = downloadDir + "/" + sanitizedName + "_" + versionName + ".zip";
+```
+
+`versionName` is scraped anchor text (`src/ModifierParser.cpp:445`, `:479`, `:513` — e.g.
+`attachmentMatch.captured(2).trimmed()`). `ModifierInfoManager::formatVersionString`
+(`src/ModifierInfoManager.cpp:90`) returns the string unchanged when it matches neither the
+numeric nor the `v`-prefix pattern, so arbitrary text reaches the path. `meta.tempPath`
+inherits it as well (`src/Backend.cpp:935`).
+
+This does not require an attacker: a plausible label such as `Steam/Epic` makes
+`NetworkManager` `mkpath` an unintended subdirectory (`src/NetworkManager.cpp:211`), and the
+file lands where the rename logic does not expect it. With a compromised or hostile page it
+is a straightforward write outside the download directory.
+
+The asymmetry with the carefully sanitized name directly beside it reads as an oversight
+rather than a deliberate choice.
+
+## 3. `m_currentDownloadReply` is never initialized
+
+**Location:** `src/include/NetworkManager.h:114` · **Severity:** Low–Medium (latent) · **Implemented:** ❌ No
+
+The member has no default initializer and is absent from the constructor's initialiser list
+(`src/NetworkManager.cpp:10-13`), which sets only `m_networkManager` and `m_timeoutInterval`.
+`cancelDownload()` dereferences it.
+
+**Reachability, stated precisely.** In the shipped application this is currently masked:
+`DownloadManager::cancelDownload` gates on `m_isDownloading` (`src/DownloadManager.cpp:139`),
+the assignment at `src/NetworkManager.cpp:246` happens synchronously right after `get()`,
+and the `file->open()` failure path self-heals because the finished callback resets
+`m_isDownloading` before control returns.
+
+The reachable trigger today is the **test hook**: `downloadFileWithStatus` returns at
+`src/NetworkManager.cpp:204` before the assignment, so a test whose handler defers its
+callback and then cancels reads an indeterminate pointer.
+
+It is undefined behaviour regardless, and one refactor away from being reachable in
+production. `= nullptr` is the entire fix.
+
+## 4. `file->write()` result discarded, so short writes report success
+
+**Location:** `src/NetworkManager.cpp:295` · **Severity:** Low · **Implemented:** ❌ No
+
+```cpp
+*bytesWritten += data.size();
+file->write(data);
+```
+
+`bytesWritten` counts bytes *received*, not bytes *persisted*. Nothing checks the write
+result or calls `flush()` / `error()` before `file->close()`. Success is then decided by
+`fileSize == 0 || *bytesWritten == 0` (`src/NetworkManager.cpp:326`).
+
+On a full disk or a write error both values are non-zero, so a truncated archive is reported
+as a completed download and is renamed out of `.crdownload` into the user's library.
+
+---
+
+## Verified correct — do not "fix" these
+
+Several things that looked like candidate problems are handled properly, recorded here so
+they are not undone later:
+
+- `CoverExtractor` keeps `QPixmap` on the GUI thread and passes `QImage` across the worker
+  boundary (`src/CoverExtractor.cpp:93-105`).
+- It already serialises the shared YOLO detector behind a mutex because `detect()` mutates a
+  `mutable` buffer (`src/CoverExtractor.cpp:174`; confirmed at
+  `third_party/YOLOs-CPP/yolos/tasks/detection.hpp:146`).
+- The cover and search staleness guards (`m_coverRequestId`, `m_activeSearchRequestId`) are
+  correct, and `coverGameId` sanitises properly.
+- `m_downloadTaskMeta` is cleaned up on task removal (`src/Backend.cpp:548`).
+- The callback `QPointer` context guards in `NetworkManager` are sound.
+- `parseModifierDetailHTML` never returns null, so the unchecked dereference at
+  `src/ModifierManager.cpp:62` is safe as the code stands.
+
+## Related
+
+A separate documentation-accuracy review earlier the same day checked `CLAUDE.md` against
+the source and found four incorrect claims (the `NetworkManager`/`CoverExtractor` HTTP
+boundary, an `i18n check` CI gate that does not exist, `metadata.schema_version` described as
+required, and the cover request-id attributed to the wrong class). Those four **were**
+applied to `CLAUDE.md`; they were documentation fixes and changed no application code.

--- a/docs/pull-requests/2026-08-26-claude-md-and-code-review.md
+++ b/docs/pull-requests/2026-08-26-claude-md-and-code-review.md
@@ -1,0 +1,75 @@
+# PR：补全 CLAUDE.md 并归档一次代码审查
+
+- **日期：** 2026-08-26
+- **分支：** `docs/claude-md-and-code-review` → `main`
+- **基线提交：** `6ae1341`
+- **性质：** 纯文档改动，**未改动任何应用代码**
+
+## 关联
+
+无对应 Issue。本 PR 解决两件事：
+
+1. 仓库根目录的 `CLAUDE.md` 此前只有一行内容（指向 `AGENTS.md`），对 Claude Code
+   没有实际帮助，且在工作区中处于被删除状态。
+2. 一次针对 `src/` 网络与下载链路的代码审查产出了 4 条问题，需要有地方留档，
+   否则结论只存在于会话里。
+
+## 改了什么
+
+### 1. `CLAUDE.md`（重写）
+
+从一行指针扩写为完整的项目指引，内容都是需要交叉阅读多个文件才能得出的信息：
+
+- **构建与测试**：`build.cmd` 各子命令；在 WSL 下必须用 `cmd.exe /c` 调用；
+  ctest 只注册了一个聚合测试，跑单个用例要直接调可执行文件加 `--gtest_filter`，
+  且必须在构建目录根部运行（`CoverExtractor` 依赖 `applicationDirPath()` 旁边的
+  `onnxruntime.dll` 与 `models/`）。
+- **架构**：`Backend` 是唯一的 QML 桥接对象；`src/` 下各管理器为回调驱动的单例、
+  不感知 QML；样式全在 `ThemeProvider.qml`，C++ `ThemeManager` 只存索引；
+  新增 QML 文件必须登记进 `qt_add_qml_module`；翻译库内置版与 AppData 覆盖层的
+  择优逻辑与必需字段；启动器与 `app\` 目录的打包结构。
+- **测试**：测试与主程序共用 `TESTABLE_PROJECT_SOURCES`，因此直接链接生产单例；
+  新测试文件需加入 `TEST_SOURCES`；`tests/fixtures/` 提供的隔离接缝。
+- **注意事项**：版本号由 git tag 推导、vcpkg triplet 与 `builtin-baseline`、
+  i18n 流程，以及 `agents/prompts/knowledge_base.md` 是与本项目无关的 WebRTC 残留。
+
+其中 4 条初稿中的错误说法已在本 PR 内自查修正：`NetworkManager` 并非唯一发起 HTTP 的
+位置（`CoverExtractor` 自持 `QNetworkAccessManager`，因此绕过测试钩子）、CI 并没有
+`i18n check` 门禁、`metadata.schema_version` 并非必需字段、封面防陈旧的 request id
+位于 `Backend` 而非 `CoverExtractor`。
+
+### 2. `docs/code-reviews/2026-08-26-network-download-code-review.md`（新增）
+
+归档一次代码审查记录，含 4 条问题：
+
+| # | 问题 | 严重度 | 是否已修复 |
+|---|------|--------|------------|
+| 1 | 暂停/取消会中止错误的下载任务 | Medium | ❌ 否 |
+| 2 | 远端抓取的版本文本未经清洗即拼入保存路径 | Medium | ❌ 否 |
+| 3 | `m_currentDownloadReply` 未初始化 | Low–Medium（潜在） | ❌ 否 |
+| 4 | `file->write()` 返回值被丢弃，短写会被判为成功 | Low | ❌ 否 |
+
+文档同时记录了「已确认正确、不要误改」的若干处（`CoverExtractor` 的线程边界与检测器
+互斥锁、各处防陈旧 guard、`QPointer` 上下文保护等），以及本次未覆盖的范围。
+
+## 怎么验证
+
+- [ ] `build.cmd tests` — **本 PR 未运行**。改动仅为 Markdown 文档，不进入任何构建
+      目标，`CMakeLists.txt`、`src/`、`qml/`、`tests/`、`resources/` 均未触及。
+- [ ] 本地跑过相关界面 / 下载 / 搜索路径 — 不适用，无行为变更。
+
+文档中引用的每一处 `file:line` 均已逐条比对源码核对过（初稿有 6 处行号因误读
+`grep -A` 偏移而写错，已更正）。
+
+## 检查项
+
+- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
+- [x] UI / QML 改动附了截图 —— 不适用，无 UI 改动
+- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明 —— 均未改动
+- [x] AI 使用披露：**是**。`CLAUDE.md`、代码审查记录与本 PR 文档均由 Claude Code
+      起草；代码审查结论由其阅读 `src/` 源码并追踪调用链得出，其中的行号与事实性
+      结论已逐条回查源码验证。本 PR 不含任何由模型生成的应用代码。
+
+## 后续
+
+本 PR 只做留档，不修复上述 4 条问题。若要跟进，建议顺序为 #1、#2。


### PR DESCRIPTION
## 关联

无对应 Issue。本 PR 解决两件事：

1. 仓库根目录的 `CLAUDE.md` 此前只有一行内容（指向 `AGENTS.md`），对 Claude Code 没有实际帮助，且在工作区中处于被删除状态。
2. 一次针对 `src/` 网络与下载链路的代码审查产出了 4 条问题，需要有地方留档，否则结论只存在于会话里。

完整说明见 `docs/pull-requests/2026-08-26-claude-md-and-code-review.md`。

## 改了什么

**纯文档改动，未改动任何应用代码。**

### 1. `CLAUDE.md`（重写）

从一行指针扩写为完整项目指引，内容都是需要交叉阅读多个文件才能得出的信息：

- **构建与测试**：`build.cmd` 各子命令；在 WSL 下必须用 `cmd.exe /c` 调用；ctest 只注册了一个聚合测试，跑单个用例要直接调可执行文件加 `--gtest_filter`，且必须在构建目录根部运行（`CoverExtractor` 依赖 `applicationDirPath()` 旁边的 `onnxruntime.dll` 与 `models/`）。
- **架构**：`Backend` 是唯一的 QML 桥接对象；`src/` 下各管理器为回调驱动的单例、不感知 QML；样式全在 `ThemeProvider.qml`，C++ `ThemeManager` 只存索引；新增 QML 文件必须登记进 `qt_add_qml_module`；翻译库内置版与 AppData 覆盖层的择优逻辑与必需字段；启动器与 `app\` 目录的打包结构。
- **测试**：测试与主程序共用 `TESTABLE_PROJECT_SOURCES`，因此直接链接生产单例；新测试文件需加入 `TEST_SOURCES`；`tests/fixtures/` 提供的隔离接缝。
- **注意事项**：版本号由 git tag 推导、vcpkg triplet 与 `builtin-baseline`、i18n 流程，以及 `agents/prompts/knowledge_base.md` 是与本项目无关的 WebRTC 残留。

初稿中有 4 条错误说法已自查修正：`NetworkManager` 并非唯一发起 HTTP 的位置（`CoverExtractor` 自持 `QNetworkAccessManager`，因此绕过测试钩子）、CI 并没有 `i18n check` 门禁、`metadata.schema_version` 并非必需字段、封面防陈旧的 request id 位于 `Backend` 而非 `CoverExtractor`。

### 2. `docs/code-reviews/`（新增目录）

归档一次网络与下载链路的代码审查，含 4 条问题，**均未修复**：

| # | 问题 | 严重度 | 是否已修复 |
|---|------|--------|------------|
| 1 | 暂停/取消会中止错误的下载任务（三处下载共用 `m_currentDownloadReply`） | Medium | ❌ 否 |
| 2 | 远端抓取的版本文本未经清洗即拼入保存路径 | Medium | ❌ 否 |
| 3 | `m_currentDownloadReply` 未初始化 | Low–Medium（潜在） | ❌ 否 |
| 4 | `file->write()` 返回值被丢弃，短写会被判为成功 | Low | ❌ 否 |

文档同时记录了「已确认正确、不要误改」的若干处（`CoverExtractor` 的线程边界与检测器互斥锁、各处防陈旧 guard、`QPointer` 上下文保护等），以及本次未覆盖的范围。

### 3. `docs/pull-requests/`（新增目录）

本 PR 的说明文档。

## 怎么验证

- [ ] `build.cmd tests` — **本 PR 未运行**。改动仅为 Markdown 文档，不进入任何构建目标，`CMakeLists.txt`、`src/`、`qml/`、`tests/`、`resources/` 均未触及。
- [ ] 本地跑过相关界面 / 下载 / 搜索路径 — 不适用，无行为变更。

文档中引用的每一处 `file:line` 均已逐条比对源码核对过（初稿有 6 处行号因误读 `grep -A` 偏移而写错，已更正）。

## 检查项

- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
- [x] UI / QML 改动附了截图 —— 不适用，无 UI 改动
- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明 —— 均未改动
- [x] AI 使用披露：**是**。`CLAUDE.md`、代码审查记录与本 PR 文档均由 Claude Code 起草；代码审查结论由其阅读 `src/` 源码并追踪调用链得出，其中的行号与事实性结论已逐条回查源码验证。本 PR 不含任何由模型生成的应用代码。

## 后续

本 PR 只做留档，不修复上述 4 条问题。若要跟进，建议顺序为 #1、#2。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
