### PR TITLE
fix(download): 修复代码审查发现的 4 个下载链路问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,9 @@ onnxruntime-win-*
 __cmake_systeminformation
 
 # Agents
-agents/
+agents/*
+# ...except the shared skills, which are part of the repo, not local scratch.
+!agents/skills/
 
 tools/qt6-qml-module-migration.md
 tools/game-mappings-updater

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,18 +133,16 @@ in `tests/resources/fling_trainer_screenshot/`).
 Three documentation steps are mandatory, not optional extras. Each writes a
 `YYYY-MM-DD-<topic>.md` file under its own `docs/` subdirectory:
 
-- **After any request that changes files, write a work log** in `docs/work-logs/` as
-  `YYYY-MM-DD-<topic>.md`: what was asked (quote the request), the plan that was
-  agreed, every file touched and why, how it was verified, and what was left open.
-  One file per request; append to the day's file when a request is a follow-up.
-- **After reviewing code, archive the review** in `docs/code-reviews/` as
-  `YYYY-MM-DD-<short-title>.md`. Record the date, the commit reviewed, the scope *and*
-  what was explicitly not covered, and a findings table whose last column states whether
-  each finding is implemented. A review that only exists in the conversation is lost.
-- **Before opening a pull request, write the PR record** in `docs/pull-requests/` as
-  `YYYY-MM-DD-<branch-topic>.md`, then use it as the PR body. Follow the sections in
-  `.github/pull_request_template.md` (关联 / 改了什么 / 怎么验证 / 检查项); these docs
-  and the PR body are written in Chinese, matching `CONTRIBUTING.md`.
+| Trigger | Record | Language |
+|---------|--------|----------|
+| Any request that changes files | `docs/work-logs/` — request (quoted), plan, every file touched and why, verification, what was left open | Chinese |
+| Any code review | `docs/code-reviews/` — commit reviewed, scope *and* what was not covered, findings table whose last column says whether each finding is implemented | English |
+| Before opening a pull request | `docs/pull-requests/` — written first, then used as the PR body, following `.github/pull_request_template.md` (关联 / 改了什么 / 怎么验证 / 检查项) | Chinese |
+
+**Read [`agents/skills/project-records/SKILL.md`](agents/skills/project-records/SKILL.md)
+before writing any of the three** — it holds the templates, the cross-linking rules, and
+how to add a fourth record type. The table above is the trigger list; the skill is the
+how.
 
 Never tick a verification box for a command you did not run — say so and leave it
 unchecked. `CONTRIBUTING.md` requires the AI-assistance disclosure to be filled in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,28 @@ workflows, `tests/performance/` Google Benchmark cases (built separately with
 `-DFLING_BUILD_BENCHMARKS=ON`; only `CoverExtractor` is covered, over the sample images
 in `tests/resources/fling_trainer_screenshot/`).
 
+## Mandatory records
+
+Three documentation steps are mandatory, not optional extras. Each writes a
+`YYYY-MM-DD-<topic>.md` file under its own `docs/` subdirectory:
+
+- **After any request that changes files, write a work log** in `docs/work-logs/` as
+  `YYYY-MM-DD-<topic>.md`: what was asked (quote the request), the plan that was
+  agreed, every file touched and why, how it was verified, and what was left open.
+  One file per request; append to the day's file when a request is a follow-up.
+- **After reviewing code, archive the review** in `docs/code-reviews/` as
+  `YYYY-MM-DD-<short-title>.md`. Record the date, the commit reviewed, the scope *and*
+  what was explicitly not covered, and a findings table whose last column states whether
+  each finding is implemented. A review that only exists in the conversation is lost.
+- **Before opening a pull request, write the PR record** in `docs/pull-requests/` as
+  `YYYY-MM-DD-<branch-topic>.md`, then use it as the PR body. Follow the sections in
+  `.github/pull_request_template.md` (关联 / 改了什么 / 怎么验证 / 检查项); these docs
+  and the PR body are written in Chinese, matching `CONTRIBUTING.md`.
+
+Never tick a verification box for a command you did not run — say so and leave it
+unchecked. `CONTRIBUTING.md` requires the AI-assistance disclosure to be filled in
+honestly.
+
 ## Gotchas
 
 - The app version is derived from `git describe --tags` at configure time and injected as

--- a/agents/skills/project-records/SKILL.md
+++ b/agents/skills/project-records/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: project-records
+description: Write the mandatory FLiNG Downloader documentation records — a work log after any request that changes files, a code-review archive after reviewing code, and a PR record before opening a pull request. Use whenever finishing such a request, review, or PR.
+---
+
+# Project records
+
+This repository keeps three kinds of permanent records under `docs/`. They are
+mandatory, not optional extras: a decision that exists only in a conversation is lost
+the moment the session ends.
+
+## The three records
+
+| Record | Trigger | Directory | Language |
+|--------|---------|-----------|----------|
+| Work log | Any request that changes files | `docs/work-logs/` | Chinese |
+| Code review | Any code review | `docs/code-reviews/` | English |
+| PR record | Before opening a pull request | `docs/pull-requests/` | Chinese |
+
+All three use the filename `YYYY-MM-DD-<topic>.md`, where `<topic>` is a short
+kebab-case slug — for a PR record, the branch topic. Use the real current date, and
+write dates absolutely (`2026-08-28`, never "today" or "last week").
+
+Cross-link the records for one piece of work: the work log links to the review and the
+PR record, the review's status summary links to the work log, and the PR record links to
+both. Use repo-relative links (`../work-logs/...`) so they resolve on GitHub.
+
+## Rules that apply to all three
+
+- **Never tick a verification box for a command you did not run.** Leave it unchecked and
+  say why in the surrounding prose. This is the rule most likely to be quietly broken;
+  breaking it makes every other record untrustworthy.
+- **State the verification status explicitly**, including "not built, not tested". The
+  build is Windows-only (`build.cmd`, Visual Studio 2022, Qt); work done from WSL cannot
+  run it, and that is a fact for the record, not an excuse to omit.
+- `CONTRIBUTING.md` requires the **AI-assistance disclosure** to be filled in honestly:
+  which parts were AI-generated, and whether they were verified.
+- Record what was **not** done or **not** covered as carefully as what was. Scope
+  boundaries are the part a future reader cannot reconstruct.
+- Quote the user's request verbatim rather than paraphrasing it.
+
+## 1. Work log — `docs/work-logs/YYYY-MM-DD-<topic>.md`
+
+Written after any request that changes files, capturing the whole request → plan →
+change cycle. One file per request; append a new section to the day's file when a
+request is a direct follow-up to one already logged there.
+
+```markdown
+# 工作记录：<一句话主题>
+
+- **日期：** YYYY-MM-DD
+- **分支：** `<branch>`（基于 `main` 的 `<commit>`）
+- **关联文档：** 链接到审查归档 / PR 记录（如果有）
+
+## 一、用户的请求
+> 逐字引用请求原文
+简述这条请求实际要求做的事。
+
+## 二、制定的计划
+按顺序列出实际执行的计划步骤。
+
+## 三、具体改了哪些文件
+| 文件 | 改动 |  ← 代码改动再加一列「对应问题」
+说明每个文件为什么改，而不只是改了什么。
+
+## 四、验证情况
+跑了什么、没跑什么、为什么。没跑就直说。
+
+## 五、遗留事项
+未完成、未覆盖、需要后续处理的部分。
+```
+
+## 2. Code review — `docs/code-reviews/YYYY-MM-DD-<short-title>.md`
+
+Written after reviewing code, whether or not anything is fixed as a result.
+
+```markdown
+# <Title> Code Review
+
+- **Date:** YYYY-MM-DD
+- **Reviewed at commit:** `<sha>` (branch)
+- **Scope:** what was read, and how (source reading, call-path tracing, running it)
+- **Not covered:** the parts deliberately left out
+
+## Status summary
+One paragraph on whether the findings are implemented, plus the findings table.
+
+| # | Finding | Severity | Implemented |
+|---|---------|----------|-------------|
+| 1 | ... | Medium | ❌ No — open  /  ✅ Yes — YYYY-MM-DD |
+
+## <n>. <Finding title>
+**Location:** `file:line` · **Severity:** ... · **Implemented:** ...
+What is wrong, the concrete path that reaches it, and how reachable it actually is —
+state reachability honestly instead of inflating severity.
+**Fix.** Added when the finding is implemented; describes the change, not the intent.
+
+## Verified correct — do not "fix" these
+Things that looked like defects but are handled properly, so nobody undoes them later.
+```
+
+The `Implemented` column is the point of the document: keep it current. When findings are
+later fixed, update this file in place — do not start a second review document for the
+same review. Line numbers stay as they were at review time; the header records the commit.
+
+## 3. PR record — `docs/pull-requests/YYYY-MM-DD-<branch-topic>.md`
+
+Written **before** opening the pull request, then used as the PR body. Follow the
+sections in `.github/pull_request_template.md` exactly:
+
+```markdown
+# PR：<标题>
+
+- **日期：** / **分支：** `<branch>` → `main` / **基线提交：** `<sha>` / **关联记录：**
+
+## 关联
+对应 Issue，或要解决的问题。
+
+## 改了什么
+用户或开发者能观察到的变化。不要只贴文件列表。
+
+## 怎么验证
+- [ ] `build.cmd tests`
+- [ ] 本地跑过相关界面 / 下载 / 搜索路径
+没执行就留空，并写明为什么、以及合并前需要谁在什么环境补跑。
+
+## 检查项
+- [ ] 已阅读 CONTRIBUTING.md
+- [ ] UI / QML 改动附了截图（不适用可删）
+- [ ] 若改动了翻译库、i18n、模型或打包资源，已在上文写明
+- [ ] AI 使用披露：否 / 是（说明用在哪一部分）
+```
+
+The PR body and this file should say the same thing. The PR body ends with the Claude Code
+generation line; the file does not need it.
+
+## Extending this skill
+
+A new record type needs three things: a trigger, a directory under `docs/`, and a
+template here. Add a row to the table above and a numbered section, then add the trigger
+to the `Mandatory records` section of `CLAUDE.md` so it is reachable without loading this
+file. Keep the naming convention (`YYYY-MM-DD-<topic>.md`) — it is what makes the
+directories sortable and greppable by date.

--- a/docs/code-reviews/2026-08-26-network-download-code-review.md
+++ b/docs/code-reviews/2026-08-26-network-download-code-review.md
@@ -9,24 +9,25 @@
 
 ## Status summary
 
-**No finding in this document has been implemented.** The review produced no code changes;
-every item below is open. The only file modified in the session that produced this review
-was `CLAUDE.md` (documentation), not application code.
+**All four findings have been implemented** on branch `fix/download-review-findings`
+(2026-08-28). The fixes were written and reviewed by reading the source; they have **not**
+been compiled or run, because the build is Windows-only and this work was done from WSL.
+See the Implementation record section below for what changed, and
+[`docs/work-logs/2026-08-28-download-review-findings.md`](../work-logs/2026-08-28-download-review-findings.md)
+for the full work log.
 
 | # | Finding | Severity | Implemented |
 |---|---------|----------|-------------|
-| 1 | Pause/cancel can abort the wrong download | Medium | ❌ No — open |
-| 2 | Remote-derived version text reaches the save path unsanitized | Medium | ❌ No — open |
-| 3 | `m_currentDownloadReply` is never initialized | Low–Medium (latent) | ❌ No — open |
-| 4 | `file->write()` result discarded, so short writes report success | Low | ❌ No — open |
-
-Suggested order if these get picked up: #1 and #2 first.
+| 1 | Pause/cancel can abort the wrong download | Medium | ✅ Yes — 2026-08-28 |
+| 2 | Remote-derived version text reaches the save path unsanitized | Medium | ✅ Yes — 2026-08-28 |
+| 3 | `m_currentDownloadReply` is never initialized | Low–Medium (latent) | ✅ Yes — 2026-08-28 |
+| 4 | `file->write()` result discarded, so short writes report success | Low | ✅ Yes — 2026-08-28 |
 
 ---
 
 ## 1. Pause/cancel can abort the wrong download
 
-**Location:** `src/NetworkManager.cpp:463` · **Severity:** Medium · **Implemented:** ❌ No
+**Location:** `src/NetworkManager.cpp:463` · **Severity:** Medium · **Implemented:** ✅ Yes
 
 `NetworkManager` tracks exactly one in-flight download in `m_currentDownloadReply`, but
 three independent features write to it:
@@ -49,11 +50,19 @@ The modifier download keeps running while the app update dies silently, and the 
 still marks the modifier "paused".
 
 **Root cause:** a single shared reply handle for logically independent transfers.
-**Direction:** give each download its own handle, or key the abort by task id.
+
+**Fix.** `NetworkManager` now keeps `QHash<QString, QNetworkReply*> m_activeDownloads`,
+keyed by destination path, and `cancelDownload()` became `cancelDownload(const QString&
+savePath)` — it can only abort the transfer writing to the path the caller names.
+`DownloadManager` remembers its own `m_currentSavePath` and passes it, so cancelling a
+modifier download cannot touch the installer or database transfer. Entries are removed
+through `unregisterDownload(savePath, reply)`, which erases only when the stored reply is
+still the one finishing, so a later download to the same path is not dropped by an earlier
+one's cleanup.
 
 ## 2. Remote-derived version text reaches the save path unsanitized
 
-**Location:** `src/Backend.cpp:434` · **Severity:** Medium · **Implemented:** ❌ No
+**Location:** `src/Backend.cpp:434` · **Severity:** Medium · **Implemented:** ✅ Yes
 
 `downloadModifier` sanitizes the modifier name — strips `\ / : * ? " < > |`, trims, removes
 trailing dots — then concatenates an unsanitized sibling value:
@@ -76,9 +85,16 @@ is a straightforward write outside the download directory.
 The asymmetry with the carefully sanitized name directly beside it reads as an oversight
 rather than a deliberate choice.
 
+**Fix.** The inline sanitization was extracted into `sanitizePathComponent(text, fallback)`
+in the anonymous namespace of `src/Backend.cpp`, and **both** components now go through it.
+It replaces `\ / : * ? " < > |` and control characters with `_`, trims, strips leading and
+trailing dots, and falls back to a placeholder when nothing is left — so neither half can
+introduce a separator or escape `downloadDir`. The unsanitized `versionName` is still stored
+in the task as the display label; only the path is sanitized.
+
 ## 3. `m_currentDownloadReply` is never initialized
 
-**Location:** `src/include/NetworkManager.h:114` · **Severity:** Low–Medium (latent) · **Implemented:** ❌ No
+**Location:** `src/include/NetworkManager.h:114` · **Severity:** Low–Medium (latent) · **Implemented:** ✅ Yes
 
 The member has no default initializer and is absent from the constructor's initialiser list
 (`src/NetworkManager.cpp:10-13`), which sets only `m_networkManager` and `m_timeoutInterval`.
@@ -95,11 +111,17 @@ The reachable trigger today is the **test hook**: `downloadFileWithStatus` retur
 callback and then cancels reads an indeterminate pointer.
 
 It is undefined behaviour regardless, and one refactor away from being reachable in
-production. `= nullptr` is the entire fix.
+production.
+
+**Fix.** The raw pointer member is gone. Finding #1 replaced it with a `QHash`, which is
+default-constructed empty, so the uninitialized read is structurally impossible rather than
+merely initialized away. `tests/unit/download_manager_test.cpp` gained
+`CancelDownloadWithoutActiveTransferIsSafe`, which cancels an unknown path with nothing in
+flight — the exact shape that used to read indeterminate memory.
 
 ## 4. `file->write()` result discarded, so short writes report success
 
-**Location:** `src/NetworkManager.cpp:295` · **Severity:** Low · **Implemented:** ❌ No
+**Location:** `src/NetworkManager.cpp:295` · **Severity:** Low · **Implemented:** ✅ Yes
 
 ```cpp
 *bytesWritten += data.size();
@@ -112,6 +134,13 @@ result or calls `flush()` / `error()` before `file->close()`. Success is then de
 
 On a full disk or a write error both values are non-zero, so a truncated archive is reported
 as a completed download and is renamed out of `.crdownload` into the user's library.
+
+**Fix.** `readyRead` now compares `file->write(data)` against `data.size()`, counts only the
+bytes actually persisted, and raises a `writeFailed` flag on a short write. The finished
+handler calls `flush()` and reads `file->error()` **before** `close()` (which clears it), and
+a raised flag turns into a failed callback carrying the file's error string instead of a
+success. The partial file is removed unless `keepPartialOnAbort` is set, in which case it is
+kept so the transfer can resume once the disk has room.
 
 ---
 
@@ -131,6 +160,18 @@ they are not undone later:
 - The callback `QPointer` context guards in `NetworkManager` are sound.
 - `parseModifierDetailHTML` never returns null, so the unchecked dereference at
   `src/ModifierManager.cpp:62` is safe as the code stands.
+
+## Implementation record
+
+| Finding | Files touched |
+|---------|---------------|
+| 1, 3 | `src/NetworkManager.{h,cpp}`, `src/DownloadManager.{h,cpp}`, `tests/unit/download_manager_test.cpp` |
+| 2 | `src/Backend.cpp` |
+| 4 | `src/NetworkManager.cpp` |
+
+**Verification status:** not built and not run. `build.cmd tests` requires Visual Studio and
+Qt on Windows; this branch was prepared from WSL. The changes need a Windows build before the
+PR is merged.
 
 ## Related
 

--- a/docs/pull-requests/2026-08-28-download-review-findings.md
+++ b/docs/pull-requests/2026-08-28-download-review-findings.md
@@ -82,3 +82,18 @@
 3. 开 PR 前先写 `docs/pull-requests/YYYY-MM-DD-<branch-topic>.md` 并用作 PR 正文。
 
 同时写明：没有真正执行过的验证命令不许打勾。
+
+### 规则抽成可复用的 skill
+
+上述规则随后被抽到 `agents/skills/project-records/SKILL.md`：三类记录的触发条件与目录
+对照表、各自的模板骨架、跨文档互链约定，以及「如何新增第四类记录」的扩展指引。
+`CLAUDE.md` 里保留触发表（不加载 skill 也要能看到「什么时候欠一份文档」），细节指向 skill。
+
+配套改了 `.gitignore`：原先第 111 行整个忽略 `agents/`，放在那里的 skill 永远提交不上去，
+别人克隆后只会看到 `CLAUDE.md` 指向一个不存在的文件。现改为 `agents/*` 加一条
+`!agents/skills/` 反向规则，只放出共享的 skill 目录，`agents/prompts/` 维持忽略不变。
+
+**已知限制：** Claude Code 只在 `.claude/skills/<name>/SKILL.md` 下自动发现 skill，
+放在 `agents/skills/` 里它是一份由 `CLAUDE.md` 引用的文档，而不是可直接调用的技能。
+文件本身带了 YAML frontmatter，若要改成可调用，整个目录移到 `.claude/skills/` 即可，
+内容无需改动。

--- a/docs/pull-requests/2026-08-28-download-review-findings.md
+++ b/docs/pull-requests/2026-08-28-download-review-findings.md
@@ -1,0 +1,84 @@
+# PR：修复代码审查发现的 4 个下载链路问题
+
+- **日期：** 2026-08-28
+- **分支：** `fix/download-review-findings` → `main`
+- **基线提交：** `c894252`
+- **关联记录：** [工作记录](../work-logs/2026-08-28-download-review-findings.md)、
+  [代码审查归档](../code-reviews/2026-08-26-network-download-code-review.md)
+
+## 关联
+
+无对应 Issue。2026-08-26 那次对 `src/` 网络与下载链路的审查留下 4 条问题，
+当时只归档没有实现（PR #38）。本 PR 把这 4 条全部改掉，并把归档文档里的
+「Implemented」列同步为已实现。
+
+## 改了什么
+
+### 1. 取消下载不再误伤别的传输（审查 #1，Medium）
+
+`NetworkManager` 过去用一个 `m_currentDownloadReply` 记录「当前下载」，但修改器下载、
+应用安装包、翻译数据库三条互不相关的传输都会往里写，于是：先下修改器，再点更新，
+此时暂停修改器会 **abort 掉应用更新**——修改器继续下，更新静默失败，任务列表还显示「已暂停」。
+
+改为按保存路径登记：`QHash<QString, QNetworkReply*> m_activeDownloads`，
+`cancelDownload()` 改成 `cancelDownload(const QString& savePath)`，只能取消调用方指名的那一路。
+`DownloadManager` 记住自己的 `m_currentSavePath` 并传入，取消修改器下载不会碰到另外两条。
+
+### 2. 版本号进入保存路径前先净化（审查 #2，Medium）
+
+`Backend::downloadModifier` 只净化了游戏名，紧挨着的版本号直接拼进路径，而版本号是从站点
+抓来的锚文本，`formatVersionString` 匹配不上格式时会原样返回。一个 `Steam/Epic` 这样的
+标签就会让下载文件落到意料之外的子目录里；页面被污染时可以写到下载目录之外。
+
+现在抽出 `sanitizePathComponent()`，游戏名和版本号都过一遍：非法字符与控制字符替换成 `_`，
+去首尾空白与点，全被去掉时退回占位名。任务里显示用的版本文本保持原样，只有路径被净化。
+
+### 3. 消除未初始化指针（审查 #3，Low–Medium）
+
+`m_currentDownloadReply` 既没有默认初始化也不在构造函数初始化列表里，`cancelDownload()`
+会解引用它。第 1 项的改造直接把这个裸指针换成了默认构造为空的 `QHash`，问题从
+「初始化一下就好」变成「结构上不可能发生」。
+
+### 4. 写盘失败不再报告成功（审查 #4，Low）
+
+`readyRead` 里 `file->write(data)` 的返回值被丢弃，`bytesWritten` 统计的是**收到**的字节
+而不是**落盘**的字节，成功判定又只看 `fileSize == 0 || bytesWritten == 0`。磁盘写满时两者
+都非零，于是一个截断的压缩包会被当成下载完成，从 `.crdownload` 改名进用户的库里。
+
+现在比对 `write()` 的返回值、只累计真正写入的字节；`finished` 里在 `close()` 之前
+`flush()` 并读取 `file->error()`（`close()` 会清掉错误状态），写失败时回调失败并带上
+文件错误信息。未设置 `keepPartialOnAbort` 时删掉残留文件；设置了则保留，等磁盘腾出空间后续传。
+
+## 怎么验证
+
+- [ ] `build.cmd tests`
+- [ ] 本地跑过相关界面 / 下载 / 搜索路径
+
+**以上两项都没有勾选，因为确实没有执行。** 本次改动是在 WSL 里完成的，
+`build.cmd` 需要 Windows 上的 Visual Studio 2022 与 Qt，无法在此环境运行。
+代码是通过通读源码和调用链人工确认的，**合并前需要在 Windows 上补跑**：
+
+1. `cmd.exe /c build.cmd tests`；
+2. 手动验证三条路径：下载修改器时暂停/续传、下载中途触发应用更新检查、翻译数据库更新。
+
+新增的回归测试是 `tests/unit/download_manager_test.cpp` 里的
+`CancelDownloadWithoutActiveTransferIsSafe`，它复现的正是第 3 项过去会读到未初始化指针的场景。
+该文件已在 `TEST_SOURCES` 中，无需改 CMake。
+
+## 检查项
+
+- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
+- [ ] UI / QML 改动附了截图（本 PR 未改动 QML）
+- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明 —— 均未改动，也没有新增需要翻译的用户可见文案
+- [x] AI 使用披露：**是**。全部代码改动、文档与本 PR 说明均由 Claude Code 生成；
+      修复方案来自对 `src/` 源码与调用链的通读，未编译验证，见上方「怎么验证」。
+
+## 附带的规则改动
+
+`CLAUDE.md` 新增 `## Mandatory records` 一节，把三条记录规则固定下来：
+
+1. 每次「请求 → 计划 → 改文件」写 `docs/work-logs/YYYY-MM-DD-<topic>.md`；
+2. 每次代码审查后归档 `docs/code-reviews/YYYY-MM-DD-<short-title>.md`；
+3. 开 PR 前先写 `docs/pull-requests/YYYY-MM-DD-<branch-topic>.md` 并用作 PR 正文。
+
+同时写明：没有真正执行过的验证命令不许打勾。

--- a/docs/work-logs/2026-08-28-download-review-findings.md
+++ b/docs/work-logs/2026-08-28-download-review-findings.md
@@ -1,0 +1,70 @@
+# 工作记录：落实网络/下载链路代码审查的 4 条问题
+
+- **日期：** 2026-08-28
+- **分支：** `fix/download-review-findings`（基于 `main` 的 `c894252`）
+- **关联文档：** [代码审查归档](../code-reviews/2026-08-26-network-download-code-review.md)、
+  [PR 记录](../pull-requests/2026-08-28-download-review-findings.md)
+
+## 一、用户的请求
+
+本次会话共两条请求，按时间顺序：
+
+1. > "Add two rules: one to add code-reviews after the review, and the other to add
+   > pull-requests before submitting the pull request."
+
+   把「审查后归档到 `docs/code-reviews/`」和「开 PR 前先写 `docs/pull-requests/` 记录」
+   两条约定写进 `CLAUDE.md`，成为固定规则。
+
+2. > "This code review is not yet complete. Please help me finish it and submit a pull
+   > request. Every time I submit a request and you formulate a plan and make
+   > modifications to the files, this entire process needs to be archived in a `docs`
+   > directory. This record should document details such as the nature of my request,
+   > the plan devised, and the specific files that were modified. This is also a rule."
+
+   包含三件事：**(a)** 把 2026-08-26 那次审查里挂着的 4 条问题真正改掉；**(b)** 提交 PR；
+   **(c)** 再加一条规则——每次「请求 → 计划 → 改文件」的完整过程都要归档，也就是本文件。
+
+## 二、制定的计划
+
+1. 在 `CLAUDE.md` 中把原来的两条规则扩成三条，新增 `docs/work-logs/` 工作记录一条。
+2. 从 `origin/main` 切出新分支（上一个 PR #38 已合并，不能继续在旧分支上叠加）。
+3. 按审查文档逐条实现 4 条问题的修复，顺序为 #1 → #3 → #2 → #4；
+   其中 #3 由 #1 的数据结构改造顺带彻底消除。
+4. 更新审查归档的「Implemented」列与每条问题的修复说明。
+5. 写 PR 记录，提交并开 PR。
+
+## 三、具体改了哪些文件
+
+### 规则与文档
+
+| 文件 | 改动 |
+|------|------|
+| `CLAUDE.md` | 新增 `## Mandatory records` 一节，写明三条强制记录规则（工作记录 / 审查归档 / PR 记录），并强调没跑过的验证命令不许打勾 |
+| `docs/code-reviews/2026-08-26-network-download-code-review.md` | 4 条问题的「Implemented」由 ❌ 改为 ✅，每条补写 **Fix** 段说明改法，新增 Implementation record 小节与「未编译验证」的声明 |
+| `docs/work-logs/2026-08-28-download-review-findings.md` | 本文件（新增） |
+| `docs/pull-requests/2026-08-28-download-review-findings.md` | PR 记录（新增） |
+
+### 代码
+
+| 文件 | 对应问题 | 改动 |
+|------|----------|------|
+| `src/include/NetworkManager.h` | #1 #3 | 删除裸指针成员 `m_currentDownloadReply`，改为 `QHash<QString, QNetworkReply*> m_activeDownloads`；`cancelDownload()` 改签名为 `cancelDownload(const QString& savePath)`；新增私有 `unregisterDownload()` |
+| `src/NetworkManager.cpp` | #1 #3 #4 | 下载按保存路径登记与注销；`readyRead` 检查 `file->write()` 返回值、只累计真正写入的字节；`finished` 在 `close()` 前 `flush()` 并读取 `file->error()`，写失败时回调失败而非成功 |
+| `src/include/DownloadManager.h` | #1 | 新增成员 `m_currentSavePath`，记录自己那一路下载的目标路径 |
+| `src/DownloadManager.cpp` | #1 | 开始下载时记录路径、结束时清除；`cancelDownload()` 只取消自己的那一路（先取副本再 abort，避免同步回调把正在使用的字符串清空） |
+| `src/Backend.cpp` | #2 | 抽出 `sanitizePathComponent(text, fallback)`，游戏名与版本号**都**经过净化后再拼接保存路径；任务里显示用的版本文本保持原样 |
+| `tests/unit/download_manager_test.cpp` | #3 | 新增 `CancelDownloadWithoutActiveTransferIsSafe`：在没有任何传输时取消一个未知路径，正是过去会读到未初始化指针的场景 |
+
+## 四、验证情况
+
+**没有编译、没有跑测试。** `build.cmd tests` 需要 Windows 上的 Visual Studio 2022 与 Qt，
+本次是在 WSL 里改的代码，无法执行。改动是通过通读源码和调用链人工确认的，合并前需要在
+Windows 上跑一次 `build.cmd tests` 并实际验证下载/暂停/更新三条路径。
+
+因此 PR 的「怎么验证」两个勾选框都留空。
+
+## 五、遗留事项
+
+- 上面那次 Windows 构建与手动验证。
+- 审查文档里 `## Verified correct — do not "fix" these` 一节列出的项目本次没有改动。
+- 审查范围之外的部分（QML 层、`ModifierParser.cpp` 的正则健壮性、测试自身覆盖率）仍未审查。

--- a/docs/work-logs/2026-08-28-project-records-skill.md
+++ b/docs/work-logs/2026-08-28-project-records-skill.md
@@ -1,0 +1,59 @@
+# 工作记录：把三类文档规则抽成可复用的 skill
+
+- **日期：** 2026-08-28
+- **分支：** `fix/download-review-findings`（PR #39，基于 `main` 的 `c894252`）
+- **关联文档：** [同日工作记录](2026-08-28-download-review-findings.md)、
+  [PR 记录](../pull-requests/2026-08-28-download-review-findings.md)
+
+## 一、用户的请求
+
+> "You can extract the organization rules for these three types of documents and
+> implement them as a 'skill' to facilitate future extensibility and reuse; this skill
+> can be placed in the `agent/skill` directory, with a reference to `./agent/skill`
+> added to `CLAUDE.md`."
+
+把上一条请求里刚写进 `CLAUDE.md` 的三条记录规则（工作记录 / 审查归档 / PR 记录）抽出来，
+做成一份独立的、可扩展可复用的 skill 文档，放到 `agents/` 下，并让 `CLAUDE.md` 指向它。
+
+## 二、制定的计划
+
+1. 先看仓库里已有的 `agents/` 布局（已有 `agents/prompts/*.md`），据此把 skill 放在
+   `agents/skills/project-records/SKILL.md`，与既有目录风格一致。
+2. skill 内容不只是搬运规则，还要补上 `CLAUDE.md` 里放不下的部分：三类文档的模板骨架、
+   互相链接的方式、以及「如何新增第四类记录」的扩展说明。
+3. 用带 YAML frontmatter 的 `SKILL.md` 格式书写，这样将来若要让 Claude Code 自动发现，
+   整个目录可以原样搬到 `.claude/skills/` 下，不必改写内容。
+4. `CLAUDE.md` 里保留「什么时候要写、写到哪、用什么语言」的触发表（这部分必须不加载
+   skill 也能看到），细节改为指向 skill。
+5. 按新规则给本次请求补一份工作记录，也就是本文件。
+
+写到第 1 步时发现 `.gitignore` 第 111 行整个忽略了 `agents/`（注释写着 `# Agents`，
+`agents/prompts/*.md` 本来就是不入库的本地文件）。放在那里的 skill 永远提交不上去，
+别人克隆下来只会看到 `CLAUDE.md` 指向一个不存在的文件，与「可复用」的目标正好相反。
+因此追加一步：把 `agents/` 改成 `agents/*` 并加一条 `!agents/skills/` 反向规则，
+只把共享的 skill 目录放出来，`agents/prompts/` 维持忽略不变。
+
+## 三、具体改了哪些文件
+
+| 文件 | 改动 |
+|------|------|
+| `agents/skills/project-records/SKILL.md` | 新增。三类记录的触发条件、目录、语言对照表；三类文档各自的模板骨架；跨文档互链要求；「没跑过的命令不许打勾」等通用规则；末尾的扩展指引 |
+| `CLAUDE.md` | `## Mandatory records` 一节由三条散文改为触发表 + 指向 skill 的链接，并保留验证诚实性与 AI 披露两条硬规则 |
+| `.gitignore` | `agents/` 改为 `agents/*` 并加 `!agents/skills/`，让 skill 能入库；`agents/prompts/` 仍然被忽略 |
+| `docs/work-logs/2026-08-28-project-records-skill.md` | 本文件（新增） |
+
+## 四、验证情况
+
+纯文档改动，没有代码变化，因此没有编译也没有跑测试；`build.cmd` 仍然只能在 Windows 上跑。
+已确认的有三点：`CLAUDE.md` 中的相对链接 `agents/skills/project-records/SKILL.md` 指向的
+文件确实存在；skill 里引用的 `docs/` 子目录与 `.github/pull_request_template.md` 也都存在；
+`git status --untracked-files=all` 确认改完 `.gitignore` 后待入库的新文件只有
+`agents/skills/project-records/SKILL.md` 与本文件，`agents/prompts/` 没有被顺带放出来。
+
+## 五、遗留事项
+
+- **skill 目前不会被 Claude Code 自动加载。** Claude Code 只在 `.claude/skills/<name>/SKILL.md`
+  下发现 skill；放在 `agents/skills/` 里它是一份被 `CLAUDE.md` 引用的文档，靠 `CLAUDE.md`
+  的指引被读到，而不是一个可以用 `/project-records` 调用的技能。若希望它可被直接调用，
+  把 `agents/skills/project-records/` 整个目录移到 `.claude/skills/` 即可，文件内容不用改。
+- 本次改动尚未提交；提交后会并入已开启的 PR #39，届时需要同步更新该 PR 的正文说明。

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -22,6 +22,27 @@
 #include <QSet>
 
 namespace {
+// Make a string safe to use as a single path component: strip characters
+// Windows rejects, collapse separators, and refuse leading/trailing dots.
+// Both halves of a download file name go through this - the version label is
+// scraped from the site and is no more trustworthy than the modifier name.
+QString sanitizePathComponent(const QString& text, const QString& fallback)
+{
+    QString sanitized = text;
+    sanitized.replace(QRegularExpression("[\\\\/:*?\"<>|]"), "_");
+    // Control characters are illegal in NTFS names and never intentional here.
+    sanitized.replace(QRegularExpression("[\\x00-\\x1F]"), "_");
+    sanitized = sanitized.trimmed();
+    while (sanitized.startsWith(".")) {
+        sanitized.remove(0, 1);
+    }
+    while (sanitized.endsWith(".")) {
+        sanitized.chop(1);
+    }
+    sanitized = sanitized.trimmed();
+    return sanitized.isEmpty() ? fallback : sanitized;
+}
+
 bool containsJapaneseScript(const QString& text)
 {
     for (const QChar& ch : text) {
@@ -421,17 +442,14 @@ void Backend::downloadModifier(int versionIndex)
     QString versionName = m_selectedModifier.versions.at(idx).first;
     QString downloadDir = ConfigManager::getInstance().getDownloadDirectory();
     
-    // Sanitize filename - remove characters that are illegal in Windows file paths
-    QString sanitizedName = m_selectedModifier.name;
-    // Replace illegal characters: \ / : * ? " < > |
-    sanitizedName.replace(QRegularExpression("[\\\\/:*?\"<>|]"), "_");
-    // Also remove trailing/leading spaces and dots (Windows doesn't like them)
-    sanitizedName = sanitizedName.trimmed();
-    while (sanitizedName.endsWith(".")) {
-        sanitizedName.chop(1);
-    }
+    // Both components are remote-derived, so both are sanitized: an unescaped
+    // separator in either one would place the file outside downloadDir.
+    const QString sanitizedName =
+        sanitizePathComponent(m_selectedModifier.name, QStringLiteral("trainer"));
+    const QString sanitizedVersion =
+        sanitizePathComponent(versionName, QStringLiteral("version"));
     
-    const QString savePath = downloadDir + "/" + sanitizedName + "_" + versionName + ".zip";
+    const QString savePath = downloadDir + "/" + sanitizedName + "_" + sanitizedVersion + ".zip";
     const QString taskId = createDownloadTask(m_selectedModifier, versionName, savePath);
     LOG_DEBUG() << "Backend: queued download task:" << taskId << "for" << m_selectedModifier.name;
     processNextDownloadTask();

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -34,6 +34,7 @@ void DownloadManager::downloadFile(const QString& url,
     }
     
     m_isDownloading = true;
+    m_currentSavePath = savePath;
     
     // Use NetworkManager to download file
     NetworkManager::getInstance().downloadFile(
@@ -46,6 +47,9 @@ void DownloadManager::downloadFile(const QString& url,
         },
         [this, completedCallback, savePath](bool success, const QString& errorMsg) {
             m_isDownloading = false;
+            if (m_currentSavePath == savePath) {
+                m_currentSavePath.clear();
+            }
             
             if (success) {
                 // Skip extension correction for .crdownload temp files;
@@ -137,8 +141,12 @@ void DownloadManager::downloadModifier(const ModifierInfo& modifier,
 void DownloadManager::cancelDownload()
 {
     if (m_isDownloading) {
-        NetworkManager::getInstance().cancelDownload();
+        // Copy first: abort() can run the finished handler synchronously,
+        // which clears m_currentSavePath while we are still using it.
+        const QString savePath = m_currentSavePath;
         m_isDownloading = false;
+        m_currentSavePath.clear();
+        NetworkManager::getInstance().cancelDownload(savePath);
     }
 }
 

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -243,7 +243,7 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
     
     // Start download
     QNetworkReply* reply = m_networkManager->get(request);
-    m_currentDownloadReply = reply; // Save current download reply
+    m_activeDownloads.insert(savePath, reply); // Track this transfer by destination
     
     // Set timeout
     QTimer* timer = createTimeoutTimer(reply);
@@ -252,6 +252,7 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
     qint64* bytesWritten = new qint64(0);
     qint64* effectiveResumeFrom = new qint64(resumeFrom);
     bool* responseModeChecked = new bool(false);
+    bool* writeFailed = new bool(false);
     
     auto normalizeResponseMode = [reply, file, resumeFrom, effectiveResumeFrom, responseModeChecked, bytesWritten]() {
         if (*responseModeChecked || resumeFrom <= 0) {
@@ -287,20 +288,35 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
     });
     
     // Connect data ready signal
-    connect(reply, &QNetworkReply::readyRead, this, [reply, file, timer, bytesWritten, normalizeResponseMode]() {
+    connect(reply, &QNetworkReply::readyRead, this, [reply, file, timer, bytesWritten, writeFailed, normalizeResponseMode]() {
         timer->start(); // Reset timer
         normalizeResponseMode();
         QByteArray data = reply->readAll();
-        *bytesWritten += data.size();
-        file->write(data);
+        // Count bytes persisted, not bytes received: a full disk or a write
+        // error must not be reported as a completed download.
+        const qint64 written = file->write(data);
+        if (written != data.size()) {
+            *writeFailed = true;
+            LOG_WARN() << "NetworkManager: Short write to" << file->fileName()
+                       << "- wrote" << written << "of" << data.size()
+                       << "bytes:" << file->errorString();
+        }
+        if (written > 0) {
+            *bytesWritten += written;
+        }
     });
     
     // Connect finished signal
-    connect(reply, &QNetworkReply::finished, this, [this, reply, file, timer, bytesWritten, effectiveResumeFrom, responseModeChecked, normalizeResponseMode, url, savePath, keepPartialOnAbort, safeFinishedCallback]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, file, timer, bytesWritten, effectiveResumeFrom, responseModeChecked, writeFailed, normalizeResponseMode, url, savePath, keepPartialOnAbort, safeFinishedCallback]() {
         normalizeResponseMode();
         timer->stop();
         timer->deleteLater();
         
+        // Inspect the write state before close(); QFile clears its error there.
+        if (!file->flush() || file->error() != QFileDevice::NoError) {
+            *writeFailed = true;
+        }
+        const QString writeErrorString = file->errorString();
         file->close();
         
         // Get HTTP status code
@@ -323,6 +339,30 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
             
             LOG_DEBUG() << "NetworkManager: Final file size:" << fileSize << "bytes";
             
+            if (*writeFailed) {
+                // The transfer completed but the bytes did not reach the disk
+                // (full volume, permission loss, I/O error). Reporting success
+                // here would rename a truncated archive into the library.
+                LOG_WARN() << "NetworkManager: Download data could not be written to"
+                           << savePath << ":" << writeErrorString;
+                if (!keepPartialOnAbort) {
+                    file->remove();
+                }
+                delete bytesWritten;
+                delete effectiveResumeFrom;
+                delete responseModeChecked;
+                delete writeFailed;
+                if (safeFinishedCallback) {
+                    safeFinishedCallback(false,
+                                         "Failed to write downloaded data to disk: " + writeErrorString,
+                                         httpStatus);
+                }
+                file->deleteLater();
+                reply->deleteLater();
+                unregisterDownload(savePath, reply);
+                return;
+            }
+            
             if (fileSize == 0 || *bytesWritten == 0) {
                 LOG_DEBUG() << "NetworkManager: WARNING - Downloaded file is empty!";
                 LOG_DEBUG() << "NetworkManager: Response headers:";
@@ -340,14 +380,13 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
                     delete bytesWritten;
                     delete effectiveResumeFrom;
                     delete responseModeChecked;
+                    delete writeFailed;
                     if (safeFinishedCallback) {
                         safeFinishedCallback(false, "Server returned HTML page instead of file - download link may be invalid", httpStatus);
                     }
                     reply->deleteLater();
                     file->deleteLater();
-                    if (m_currentDownloadReply == reply) {
-                        m_currentDownloadReply = nullptr;
-                    }
+                    unregisterDownload(savePath, reply);
                     return;
                 }
                 
@@ -355,6 +394,7 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
                 delete bytesWritten;
                 delete effectiveResumeFrom;
                 delete responseModeChecked;
+                delete writeFailed;
                 if (safeFinishedCallback) {
                     safeFinishedCallback(false, "Downloaded file is empty - server may have returned no content", httpStatus);
                 }
@@ -362,6 +402,7 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
                 delete bytesWritten;
                 delete effectiveResumeFrom;
                 delete responseModeChecked;
+                delete writeFailed;
                 if (safeFinishedCallback) {
                     safeFinishedCallback(true, QString(), httpStatus);
                 }
@@ -374,14 +415,13 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
                     delete bytesWritten;
                     delete effectiveResumeFrom;
                     delete responseModeChecked;
+                    delete writeFailed;
                     if (safeFinishedCallback) {
                         safeFinishedCallback(true, QString(), httpStatus);
                     }
                     file->deleteLater();
                     reply->deleteLater();
-                    if (m_currentDownloadReply == reply) {
-                        m_currentDownloadReply = nullptr;
-                    }
+                    unregisterDownload(savePath, reply);
                     return;
                 }
             }
@@ -393,6 +433,7 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
             delete bytesWritten;
             delete effectiveResumeFrom;
             delete responseModeChecked;
+            delete writeFailed;
             if (safeFinishedCallback) {
                 safeFinishedCallback(false, reply->errorString(), httpStatus);
             }
@@ -402,10 +443,7 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
         file->deleteLater();
         reply->deleteLater();
         
-        // Clear current download reply
-        if (m_currentDownloadReply == reply) {
-            m_currentDownloadReply = nullptr;
-        }
+        unregisterDownload(savePath, reply);
     });
     
     // Connect error signal
@@ -460,10 +498,19 @@ void NetworkManager::onTimeoutTriggered()
     LOG_DEBUG() << "Network request timeout";
 }
 
-void NetworkManager::cancelDownload()
+void NetworkManager::unregisterDownload(const QString& savePath, QNetworkReply* reply)
 {
-    if (m_currentDownloadReply && m_currentDownloadReply->isRunning()) {
-        LOG_DEBUG() << "Cancelling download";
-        m_currentDownloadReply->abort();
+    const auto it = m_activeDownloads.constFind(savePath);
+    if (it != m_activeDownloads.cend() && it.value() == reply) {
+        m_activeDownloads.erase(it);
+    }
+}
+
+void NetworkManager::cancelDownload(const QString& savePath)
+{
+    QNetworkReply* reply = m_activeDownloads.value(savePath);
+    if (reply && reply->isRunning()) {
+        LOG_DEBUG() << "Cancelling download:" << savePath;
+        reply->abort();
     }
 }

--- a/src/include/DownloadManager.h
+++ b/src/include/DownloadManager.h
@@ -59,7 +59,10 @@ public:
                          bool keepPartialOnAbort = false);
     
     /**
-     * @brief Cancel current download
+     * @brief Cancel the download this manager currently owns
+     *
+     * Cancels only its own transfer; app-update and database downloads run
+     * through NetworkManager independently and are left alone.
      */
     void cancelDownload();
     
@@ -115,4 +118,6 @@ private:
     
 private:
     bool m_isDownloading;
+    // Destination of the in-flight transfer, used to cancel exactly that one.
+    QString m_currentSavePath;
 }; 

--- a/src/include/NetworkManager.h
+++ b/src/include/NetworkManager.h
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include <QString>
 #include <QUrl>
+#include <QHash>
 #include <functional>
 #include "ModifierParser.h"
 
@@ -79,8 +80,9 @@ public:
     // Abort all requests
     void abortAllRequests();
     
-    // Cancel current download
-    void cancelDownload();
+    // Cancel the download writing to savePath. Downloads are tracked per
+    // destination path, so cancelling one transfer never aborts another.
+    void cancelDownload(const QString& savePath);
 
     // Set global timeout interval (milliseconds)
     void setTimeoutInterval(int msec);
@@ -107,11 +109,15 @@ private:
     // Create timeout timer for request
     QTimer* createTimeoutTimer(QNetworkReply* reply);
 
+    // Drop savePath from the active-download table, but only when it still
+    // maps to this reply (a later download to the same path wins).
+    void unregisterDownload(const QString& savePath, QNetworkReply* reply);
+
 private:
     QNetworkAccessManager* m_networkManager;
     int m_timeoutInterval;
     QString m_globalUserAgent;
-    QNetworkReply* m_currentDownloadReply;
+    QHash<QString, QNetworkReply*> m_activeDownloads;
     TestGetRequestHandler m_testGetRequestHandler;
     TestDownloadRequestHandler m_testDownloadRequestHandler;
 

--- a/tests/unit/download_manager_test.cpp
+++ b/tests/unit/download_manager_test.cpp
@@ -160,3 +160,15 @@ TEST_F(DownloadManagerTest, DetectFileFormatReturnsEmptyWhenFileCannotBeOpened)
     const QString missingPath = tempDir.filePath(QStringLiteral("missing.tar"));
     EXPECT_TRUE(DownloadManager::getInstance().detectFileFormat(missingPath).isEmpty());
 }
+
+TEST_F(DownloadManagerTest, CancelDownloadWithoutActiveTransferIsSafe)
+{
+    // Regression: NetworkManager tracked the in-flight download in an
+    // uninitialised raw pointer, so cancelling with nothing in flight read
+    // indeterminate memory. Downloads are now keyed by destination path and an
+    // unknown path simply matches nothing.
+    NetworkManager::getInstance().cancelDownload(QStringLiteral("does/not/exist.zip"));
+
+    DownloadManager::getInstance().cancelDownload();
+    EXPECT_FALSE(DownloadManager::getInstance().isDownloading());
+}


### PR DESCRIPTION
## 关联

无对应 Issue。2026-08-26 那次对 `src/` 网络与下载链路的审查留下 4 条问题，当时只归档没有实现（#38）。本 PR 把这 4 条全部改掉，并把归档文档里的「Implemented」列同步为已实现。

完整记录见 [`docs/pull-requests/2026-08-28-download-review-findings.md`](https://github.com/Sqhh99/FLiNG-Downloader/blob/fix/download-review-findings/docs/pull-requests/2026-08-28-download-review-findings.md)。

## 改了什么

### 1. 取消下载不再误伤别的传输（审查 #1，Medium）

`NetworkManager` 过去用一个 `m_currentDownloadReply` 记录「当前下载」，但修改器下载、应用安装包、翻译数据库三条互不相关的传输都会往里写，于是：先下修改器，再点更新，此时暂停修改器会 **abort 掉应用更新**——修改器继续下，更新静默失败，任务列表还显示「已暂停」。

改为按保存路径登记：`QHash<QString, QNetworkReply*> m_activeDownloads`，`cancelDownload()` 改成 `cancelDownload(const QString& savePath)`，只能取消调用方指名的那一路。`DownloadManager` 记住自己的 `m_currentSavePath` 并传入，取消修改器下载不会碰到另外两条。

### 2. 版本号进入保存路径前先净化（审查 #2，Medium）

`Backend::downloadModifier` 只净化了游戏名，紧挨着的版本号直接拼进路径，而版本号是从站点抓来的锚文本，`formatVersionString` 匹配不上格式时会原样返回。一个 `Steam/Epic` 这样的标签就会让下载文件落到意料之外的子目录里；页面被污染时可以写到下载目录之外。

现在抽出 `sanitizePathComponent()`，游戏名和版本号都过一遍：非法字符与控制字符替换成 `_`，去首尾空白与点，全被去掉时退回占位名。任务里显示用的版本文本保持原样，只有路径被净化。

### 3. 消除未初始化指针（审查 #3，Low–Medium）

`m_currentDownloadReply` 既没有默认初始化也不在构造函数初始化列表里，`cancelDownload()` 会解引用它。第 1 项的改造直接把这个裸指针换成了默认构造为空的 `QHash`，问题从「初始化一下就好」变成「结构上不可能发生」。

### 4. 写盘失败不再报告成功（审查 #4，Low）

`readyRead` 里 `file->write(data)` 的返回值被丢弃，`bytesWritten` 统计的是**收到**的字节而不是**落盘**的字节，成功判定又只看 `fileSize == 0 || bytesWritten == 0`。磁盘写满时两者都非零，于是一个截断的压缩包会被当成下载完成，从 `.crdownload` 改名进用户的库里。

现在比对 `write()` 的返回值、只累计真正写入的字节；`finished` 里在 `close()` 之前 `flush()` 并读取 `file->error()`（`close()` 会清掉错误状态），写失败时回调失败并带上文件错误信息。未设置 `keepPartialOnAbort` 时删掉残留文件；设置了则保留，等磁盘腾出空间后续传。

## 怎么验证

- [ ] `build.cmd tests`
- [ ] 本地跑过相关界面 / 下载 / 搜索路径

**以上两项都没有勾选，因为确实没有执行。** 本次改动是在 WSL 里完成的，`build.cmd` 需要 Windows 上的 Visual Studio 2022 与 Qt，无法在此环境运行。代码是通过通读源码和调用链人工确认的，**合并前需要在 Windows 上补跑**：

1. `cmd.exe /c build.cmd tests`；
2. 手动验证三条路径：下载修改器时暂停/续传、下载中途触发应用更新检查、翻译数据库更新。

新增的回归测试是 `tests/unit/download_manager_test.cpp` 里的 `CancelDownloadWithoutActiveTransferIsSafe`，它复现的正是第 3 项过去会读到未初始化指针的场景。该文件已在 `TEST_SOURCES` 中，无需改 CMake。

## 检查项

- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
- [ ] UI / QML 改动附了截图（本 PR 未改动 QML）
- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明 —— 均未改动，也没有新增需要翻译的用户可见文案
- [x] AI 使用披露：**是**。全部代码改动、文档与本 PR 说明均由 Claude Code 生成；修复方案来自对 `src/` 源码与调用链的通读，未编译验证，见上方「怎么验证」。

## 附带的规则改动

`CLAUDE.md` 新增 `## Mandatory records` 一节，把三条记录规则固定下来：

1. 每次「请求 → 计划 → 改文件」写 `docs/work-logs/YYYY-MM-DD-<topic>.md`；
2. 每次代码审查后归档 `docs/code-reviews/YYYY-MM-DD-<short-title>.md`；
3. 开 PR 前先写 `docs/pull-requests/YYYY-MM-DD-<branch-topic>.md` 并用作 PR 正文。

同时写明：没有真正执行过的验证命令不许打勾。

### 规则抽成可复用的 skill

上述规则随后被抽到 `agents/skills/project-records/SKILL.md`：三类记录的触发条件与目录对照表、各自的模板骨架、跨文档互链约定，以及「如何新增第四类记录」的扩展指引。`CLAUDE.md` 里保留触发表（不加载 skill 也要能看到「什么时候欠一份文档」），细节指向 skill。

配套改了 `.gitignore`：原先第 111 行整个忽略 `agents/`，放在那里的 skill 永远提交不上去，别人克隆后只会看到 `CLAUDE.md` 指向一个不存在的文件。现改为 `agents/*` 加一条 `!agents/skills/` 反向规则，只放出共享的 skill 目录，`agents/prompts/` 维持忽略不变。

**已知限制：** Claude Code 只在 `.claude/skills/<name>/SKILL.md` 下自动发现 skill，放在 `agents/skills/` 里它是一份由 `CLAUDE.md` 引用的文档，而不是可直接调用的技能。文件本身带了 YAML frontmatter，若要改成可调用，整个目录移到 `.claude/skills/` 即可，内容无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

