### PR TITLE
fix(download): 修复修改器下载全部返回 403

### DIFF
--- a/docs/pull-requests/2026-09-06-download-403-referer.md
+++ b/docs/pull-requests/2026-09-06-download-403-referer.md
@@ -1,0 +1,82 @@
+# PR：修复修改器下载全部返回 403
+
+- **日期：** 2026-09-06
+- **分支：** `fix/download-referer-403` → `main`
+- **基线提交：** `bad5d7e`
+- **关联记录：** [工作记录](../work-logs/2026-09-06-download-403-referer.md)
+
+## 关联
+
+关联 issue [#40](https://github.com/Sqhh99/FLiNG-Downloader/issues/40)
+（v1.1.9，所有修改器均下载失败）。
+
+这里**故意不写 `Fixes #40`**：按维护者要求，issue 由人工确认线上表现后手动关闭，
+不通过合并自动关掉。
+
+## 改了什么
+
+上游 flingtrainer.com 给下载加了防盗链，导致**所有**修改器下载都失败。
+现在下载链路是 3 跳，最后一跳被拦：
+
+| # | URL | 结果 |
+|---|-----|------|
+| 1 | `flingtrainer.com/downloads/<token>,,` | 302 |
+| 2 | `flingtrainer.com/download-trainer.php?path=%2Fwp-content%2Fuploads%2F...zip` | 302 |
+| 3 | `flingtrainer.com/wp-content/uploads/trainer-files/2026/09/<name>.zip/<name>.exe` | **403** |
+
+用 curl 做的对照实验，确认拦截条件是**同源 Referer**，与 User-Agent 无关：
+
+| 条件 | 结果 |
+|------|------|
+| `Referer: https://flingtrainer.com/` | **200**，`application/x-msdownload`，魔数 `MZ` |
+| 不带 `Referer` | **403** |
+| `Referer: https://www.google.com/` | **403**（必须同源） |
+| 空 User-Agent + 正确 Referer | **200** |
+
+**用户能观察到的变化：** 下载重新可用，不再几秒后弹失败。落盘文件会是
+`<名称>_<版本>.exe` —— 因为第 3 跳返回的是从 zip 里解出来的 exe，而不是 zip 本身；
+`Backend` 原本就会调用 `correctFileExtension()`，`detectFileFormat()` 也早已把魔数 `MZ`
+映射成 `exe`，所以这一段无需改代码。
+
+**改动本身：** 在 `NetworkManager::downloadFileWithStatus()` 里给下载请求补上 `Referer`。
+四个 `downloadFile` / `downloadFileWithStatus` 重载最终都汇到这一个函数，
+所以只有一处构造请求的地方要改，**没有改动任何函数签名**。
+
+Referer 取目标 URL 自己的源（`scheme://host[:port]/`），而不是把详情页地址一路传下来：
+
+- 站点只校验同源，取源即可满足；
+- 同一套写法对 `AppUpdateManager` / `DatabaseUpdateManager` 的 GitHub、Gitee
+  下载同样成立，不用改它们的调用点；
+- 只保留源、丢掉 path，也避免把下载 token 泄露给跳转目标。
+
+推导逻辑单独拆成 public 静态方法 `NetworkManager::defaultRefererForUrl()`，以便写单元测试。
+
+**经实测确认不受影响、因此没有改的部分：**
+
+- 搜索页 `/?s=` 与详情页仍返回 200，href 仍是
+  `href="https://flingtrainer.com/downloads/<token>,," class="attachment-link"`，
+  `ModifierParser` 照旧能解析；`sendGetRequest()` 未改动。
+- `/wp-content/uploads/**.jpg` 封面图没有防盗链，绕开 `NetworkManager`
+  自己发请求的 `CoverExtractor` 不用动。
+- `DownloadManager::cleanUrl()` 去掉结尾 `,,` 无害：带与不带，第 1 跳跳转结果完全一样。
+- 第 3 跳支持 Range（206），`.crdownload` 断点续传这条路仍然成立。
+
+## 怎么验证
+
+- [x] `build.cmd tests`
+- [x] 本地跑过相关界面 / 下载 / 搜索路径
+
+以上两项由仓库作者在 Windows 本机执行并反馈通过。**AI 未自行构建或运行**：
+`build.cmd` 需要 Windows，而改动是在 WSL 里完成的，该环境下 interop 起不来 `cmd.exe`。
+
+新增的两个单元测试只覆盖 `defaultRefererForUrl()` 的推导（同源、保留非默认端口、
+无 scheme/host 时返回空）。现有的 `TestDownloadRequestHandler` 测试桩在构造
+`QNetworkRequest` **之前**就返回了，因此任何单元测试都无法证明这个请求头真的发上了网络 ——
+这一点只能靠上面的实跑。断点续传与扩展名纠正这两个子项，作者未单独反馈结果。
+
+## 检查项
+
+- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
+- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明（本次均未改动）
+- [x] AI 使用披露：是。上游行为的排查（curl 对照实验）、代码改动、单元测试与本记录均由
+  Claude Code 生成；构建与下载实测由作者在 Windows 上完成。

--- a/docs/work-logs/2026-09-06-download-403-referer.md
+++ b/docs/work-logs/2026-09-06-download-403-referer.md
@@ -2,7 +2,7 @@
 
 - **日期：** 2026-09-06
 - **分支：** `fix/download-referer-403`（基于 `main` 的 `bad5d7e`）
-- **关联文档：** 对应 issue [#40](https://github.com/Sqhh99/FLiNG-Downloader/issues/40)；PR 记录待构建验证通过后再写
+- **关联文档：** 对应 issue [#40](https://github.com/Sqhh99/FLiNG-Downloader/issues/40)；[PR 记录](../pull-requests/2026-09-06-download-403-referer.md)
 
 ## 一、用户的请求
 
@@ -92,9 +92,11 @@ NetworkManager: HTTP status code: 403
 
 ## 五、验证情况
 
-- **没有构建，没有跑测试。** 本次改动在 WSL 里完成，`build.cmd` 需要 Windows；
+- **AI 侧没有构建、没有跑测试。** 本次改动在 WSL 里完成，`build.cmd` 需要 Windows；
   这台机器上的 WSL interop 也起不来 `cmd.exe`（试了 `cmd.exe /c build.cmd tests`，
   cmd.exe 被当成 shell 脚本执行，报 `MZ...: not found`）。
+- **作者已在 Windows 本机构建并实测通过**（2026-09-06 反馈：测试通过，可以提 PR）。
+  断点续传与扩展名纠正这两个子项没有单独反馈结果。
 - 已完成的验证只有**对站点行为的实测**：上面那两张表全部是 curl 实跑的结果，
   包括下载成功时的 1,765,888 字节与 `MZ` 魔数。
 - 新增的单元测试只覆盖 `defaultRefererForUrl()` 的推导逻辑。
@@ -113,8 +115,8 @@ NetworkManager: HTTP status code: 403
 
 - 若实测仍然 403，说明 Qt 在重定向时丢掉了这个请求头。备用方案：把
   `RedirectPolicyAttribute` 改成手动模式，每一跳自己重新设置 `Referer`。
-- PR 记录 `docs/pull-requests/2026-09-06-download-403-referer.md` 等实测通过后再写，
-  这样「怎么验证」几个勾能如实填写实际跑过的内容，而不是留空。
+- issue #40 **不通过合并自动关闭**：PR 里只写「关联」而不写 `Fixes #40`，
+  按维护者要求由人工确认线上表现后手动关掉。
 - 工作区里还有两处与本次无关、且不是本次会话产生的内容，**没有**纳入本次提交：
   - `CMakeLists.txt` 未提交的本地改动（第 178 行 `WIN32` 被注释掉），
     这是为了让控制台日志可见的调试手法，不应提交；

--- a/docs/work-logs/2026-09-06-download-403-referer.md
+++ b/docs/work-logs/2026-09-06-download-403-referer.md
@@ -1,0 +1,122 @@
+# 工作记录：修复修改器下载全部返回 403
+
+- **日期：** 2026-09-06
+- **分支：** `fix/download-referer-403`（基于 `main` 的 `bad5d7e`）
+- **关联文档：** 对应 issue [#40](https://github.com/Sqhh99/FLiNG-Downloader/issues/40)；PR 记录待构建验证通过后再写
+
+## 一、用户的请求
+
+> An error is currently occurring with the software trainer downloads; in fact, error
+> messages appear whenever I try to download any trainer. I suspect that the URL structure
+> of the upstream software site has changed. Please help me troubleshoot and resolve this
+> issue.
+
+用户同时附上了运行日志，关键几行是：
+
+```
+NetworkManager: Error occurred during download: QNetworkReply::ContentAccessDenied
+  "... - server replied: Forbidden"
+NetworkManager: HTTP status code: 403
+```
+
+随后用户补充：
+
+> https://github.com/Sqhh99/FLiNG-Downloader/issues/40, After modifying the code, I will
+> first build and test the download functionality, then submit a PR and link it to this issue.
+
+即：先定位并修复，代码改完后由用户自己构建、实测下载，通过后再提 PR 并关联 issue #40。
+
+## 二、制定的计划
+
+1. 用 curl 直接打上游站点，把 302 跳转链完整走一遍，确认到底是哪一跳返回 403。
+2. 逐个变量做对照实验（Referer / User-Agent / 带不带结尾的 `,,`），分离出真正的原因。
+3. 确认搜索、详情页解析、封面图这几条链路是否也受影响，划清改动范围。
+4. 只改真正出问题的那一处，并补可测的单元测试。
+5. 写工作记录；PR 记录等用户实测通过后再写。
+
+## 三、排查结论
+
+上游的下载链路从 1 跳变成了 3 跳：
+
+| # | URL | 结果 |
+|---|-----|------|
+| 1 | `flingtrainer.com/downloads/<token>,,` | 302 |
+| 2 | `flingtrainer.com/download-trainer.php?path=%2Fwp-content%2Fuploads%2F...zip` | 302 |
+| 3 | `flingtrainer.com/wp-content/uploads/trainer-files/2026/09/<name>.zip/<name>.exe` | **403** |
+
+第 3 跳加了防盗链。对照实验：
+
+| 条件 | 结果 |
+|------|------|
+| `Referer: https://flingtrainer.com/` | **200**，`application/x-msdownload`，魔数 `MZ` |
+| 不带 `Referer` | **403** |
+| `Referer: https://www.google.com/` | **403**（必须同源） |
+| 空 User-Agent + 正确 Referer | **200**（UA 与此无关） |
+
+所以真正的原因是**缺少同源 `Referer` 请求头**，不是解析失败。以下经实测确认不受影响，因此不改：
+
+- 搜索页 `/?s=` 与详情页仍返回 200，href 仍是
+  `href="https://flingtrainer.com/downloads/<token>,," class="attachment-link"`，
+  `ModifierParser` 照旧能解析（用户日志里两个版本都正确识别了）。
+- `/wp-content/uploads/**.jpg` 封面图**没有**防盗链（不带 Referer 也是 200），
+  所以绕开 `NetworkManager` 自己发请求的 `CoverExtractor` 不用动。
+- `DownloadManager::cleanUrl()` 去掉结尾 `,,` 无害：带与不带，第 1 跳的跳转结果完全一样。
+- 第 3 跳支持 Range（返回 206），所以 `.crdownload` 断点续传这条路仍然成立。
+
+**一个附带变化：** 第 3 跳给出的是从 zip 里解出来的 `.exe`，不再是 zip 本身。
+但 `Backend` 在改名后本来就会调用 `DownloadManager::correctFileExtension()`，
+而 `detectFileFormat()` 早已把魔数 `MZ` 映射成 `exe`，所以文件会被自动改成 `.exe`，
+**这一段不需要改代码**，但需要在实测时确认一下。
+
+## 四、具体改了哪些文件
+
+| 文件 | 改动 | 对应问题 |
+|------|------|----------|
+| `src/include/NetworkManager.h` | 新增 public 静态方法 `defaultRefererForUrl()` 声明 | 把 Referer 推导单独拆出来，才有办法写单元测试 |
+| `src/NetworkManager.cpp` | 实现 `defaultRefererForUrl()`；在 `downloadFileWithStatus()` 里给请求设置 `Referer` | 403 的直接原因 |
+| `tests/unit/download_manager_test.cpp` | 新增两个用例，覆盖 Referer 推导 | 回归保护 |
+| `docs/work-logs/2026-09-06-download-403-referer.md` | 本文件 | CLAUDE.md 要求 |
+
+几点说明：
+
+- 四个 `downloadFile` / `downloadFileWithStatus` 重载最终都汇到同一个
+  `downloadFileWithStatus(url, savePath, context, ...)`，所以只有一处构造请求的地方要改，
+  **没有改动任何函数签名**。
+- Referer 取的是目标 URL 自己的源（`scheme://host[:port]/`），不是把详情页地址一路传下来。
+  理由：站点的规则只校验同源；取源的写法对 `AppUpdateManager` /
+  `DatabaseUpdateManager` 的 GitHub、Gitee 下载同样成立，不必改它们的调用点。
+  另外只保留源、丢掉 path，也避免把下载 token 泄露给跳转目标。
+- 没有动 `sendGetRequest()`：搜索和详情页没有被拦，改它只会扩大 diff。
+- 依赖的一个前提：Qt 会把原始请求头复制到重定向请求上。这 3 跳都是同源，所以设置一次即可
+  覆盖整条链。**这一点只能靠实跑验证**，见下。
+
+## 五、验证情况
+
+- **没有构建，没有跑测试。** 本次改动在 WSL 里完成，`build.cmd` 需要 Windows；
+  这台机器上的 WSL interop 也起不来 `cmd.exe`（试了 `cmd.exe /c build.cmd tests`，
+  cmd.exe 被当成 shell 脚本执行，报 `MZ...: not found`）。
+- 已完成的验证只有**对站点行为的实测**：上面那两张表全部是 curl 实跑的结果，
+  包括下载成功时的 1,765,888 字节与 `MZ` 魔数。
+- 新增的单元测试只覆盖 `defaultRefererForUrl()` 的推导逻辑。
+  现有的 `TestDownloadRequestHandler` 测试桩在构造 `QNetworkRequest` **之前**就返回了，
+  因此任何单元测试都无法证明这个请求头真的发上了网络 —— 那只能靠实跑。
+
+需要用户执行的验证：
+
+1. `build.cmd tests`：编译并跑测试。
+2. `build.cmd run debug`，这才是能证明修复有效的一步：
+   - 搜索并下载一个修改器，确认能下完，而不是又打印 `HTTP status code: 403`；
+   - 确认落盘文件是 `<名称>_<版本>.exe`（由魔数纠正扩展名而来），且出现在已下载列表里；
+   - 下载中途暂停再继续，确认 `.crdownload` + Range 这条路在跳转链下仍然可用。
+
+## 六、遗留事项
+
+- 若实测仍然 403，说明 Qt 在重定向时丢掉了这个请求头。备用方案：把
+  `RedirectPolicyAttribute` 改成手动模式，每一跳自己重新设置 `Referer`。
+- PR 记录 `docs/pull-requests/2026-09-06-download-403-referer.md` 等实测通过后再写，
+  这样「怎么验证」几个勾能如实填写实际跑过的内容，而不是留空。
+- 工作区里还有两处与本次无关、且不是本次会话产生的内容，**没有**纳入本次提交：
+  - `CMakeLists.txt` 未提交的本地改动（第 178 行 `WIN32` 被注释掉），
+    这是为了让控制台日志可见的调试手法，不应提交；
+  - 未跟踪文件 `docs/code-reviews/2026-09-04-ui-redundancy-performance.md` 与
+    `docs/work-logs/2026-09-04-ui-redundancy-performance.md`。

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -236,6 +236,15 @@ void NetworkManager::downloadFileWithStatus(const QString& url,
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, 
                         QNetworkRequest::NoLessSafeRedirectPolicy);
     
+    // flingtrainer.com hands trainer payloads out only to same-origin referrers:
+    // the final /wp-content/uploads/trainer-files/... hop answers 403 without this.
+    // Qt copies request headers onto redirect requests, so setting it once here
+    // covers every hop of the chain.
+    const QString referer = defaultRefererForUrl(url);
+    if (!referer.isEmpty()) {
+        request.setRawHeader("Referer", referer.toUtf8());
+    }
+    
     // Resume partial download with HTTP Range when possible.
     if (resumeFrom > 0) {
         request.setRawHeader("Range", QString("bytes=%1-").arg(resumeFrom).toUtf8());
@@ -474,6 +483,23 @@ void NetworkManager::setGlobalUserAgent(const QString& userAgent)
 QString NetworkManager::getGlobalUserAgent() const
 {
     return m_globalUserAgent;
+}
+
+QString NetworkManager::defaultRefererForUrl(const QString& url)
+{
+    const QUrl parsed(url);
+    if (parsed.scheme().isEmpty() || parsed.host().isEmpty()) {
+        return QString();
+    }
+
+    // Scheme, host and any non-default port only - never the path, which can
+    // carry a download token we have no reason to leak to a redirect target.
+    QUrl origin;
+    origin.setScheme(parsed.scheme());
+    origin.setHost(parsed.host());
+    origin.setPort(parsed.port());
+    origin.setPath(QStringLiteral("/"));
+    return origin.toString();
 }
 
 QTimer* NetworkManager::createTimeoutTimer(QNetworkReply* reply)

--- a/src/include/NetworkManager.h
+++ b/src/include/NetworkManager.h
@@ -93,6 +93,10 @@ public:
     // Get global user agent
     QString getGlobalUserAgent() const;
 
+    // Same-origin Referer for url ("https://host/"), or empty when url carries
+    // no scheme or host. Some hosts serve downloads to same-origin referrers only.
+    static QString defaultRefererForUrl(const QString& url);
+
     // Test hooks
     void setGetRequestHandlerForTesting(TestGetRequestHandler handler);
     void setDownloadRequestHandlerForTesting(TestDownloadRequestHandler handler);

--- a/tests/unit/download_manager_test.cpp
+++ b/tests/unit/download_manager_test.cpp
@@ -172,3 +172,24 @@ TEST_F(DownloadManagerTest, CancelDownloadWithoutActiveTransferIsSafe)
     DownloadManager::getInstance().cancelDownload();
     EXPECT_FALSE(DownloadManager::getInstance().isDownloading());
 }
+
+TEST_F(DownloadManagerTest, DefaultRefererKeepsOnlyTheOrigin)
+{
+    // Regression: flingtrainer.com started serving trainer payloads only to
+    // same-origin referrers, so downloads without this header answered 403.
+    EXPECT_EQ(
+        NetworkManager::defaultRefererForUrl(
+            QStringLiteral("https://flingtrainer.com/downloads/Ekm-bdRFI0A_lCbUwTEb0g,,")),
+        QStringLiteral("https://flingtrainer.com/"));
+
+    // A non-default port belongs to the origin and has to survive.
+    EXPECT_EQ(
+        NetworkManager::defaultRefererForUrl(QStringLiteral("http://localhost:8080/a/b.zip")),
+        QStringLiteral("http://localhost:8080/"));
+}
+
+TEST_F(DownloadManagerTest, DefaultRefererIsEmptyWithoutSchemeAndHost)
+{
+    EXPECT_TRUE(NetworkManager::defaultRefererForUrl(QStringLiteral("/relative/path.zip")).isEmpty());
+    EXPECT_TRUE(NetworkManager::defaultRefererForUrl(QString()).isEmpty());
+}


### PR DESCRIPTION

- **日期：** 2026-09-06
- **分支：** `fix/download-referer-403` → `main`
- **基线提交：** `bad5d7e`
- **关联记录：** [工作记录](https://github.com/Sqhh99/FLiNG-Downloader/blob/fix/download-referer-403/docs/work-logs/2026-09-06-download-403-referer.md)

## 关联

关联 issue [#40](https://github.com/Sqhh99/FLiNG-Downloader/issues/40)
（v1.1.9，所有修改器均下载失败）。

这里**故意不写 `Fixes #40`**：按维护者要求，issue 由人工确认线上表现后手动关闭，
不通过合并自动关掉。

## 改了什么

上游 flingtrainer.com 给下载加了防盗链，导致**所有**修改器下载都失败。
现在下载链路是 3 跳，最后一跳被拦：

| # | URL | 结果 |
|---|-----|------|
| 1 | `flingtrainer.com/downloads/<token>,,` | 302 |
| 2 | `flingtrainer.com/download-trainer.php?path=%2Fwp-content%2Fuploads%2F...zip` | 302 |
| 3 | `flingtrainer.com/wp-content/uploads/trainer-files/2026/09/<name>.zip/<name>.exe` | **403** |

用 curl 做的对照实验，确认拦截条件是**同源 Referer**，与 User-Agent 无关：

| 条件 | 结果 |
|------|------|
| `Referer: https://flingtrainer.com/` | **200**，`application/x-msdownload`，魔数 `MZ` |
| 不带 `Referer` | **403** |
| `Referer: https://www.google.com/` | **403**（必须同源） |
| 空 User-Agent + 正确 Referer | **200** |

**用户能观察到的变化：** 下载重新可用，不再几秒后弹失败。落盘文件会是
`<名称>_<版本>.exe` —— 因为第 3 跳返回的是从 zip 里解出来的 exe，而不是 zip 本身；
`Backend` 原本就会调用 `correctFileExtension()`，`detectFileFormat()` 也早已把魔数 `MZ`
映射成 `exe`，所以这一段无需改代码。

**改动本身：** 在 `NetworkManager::downloadFileWithStatus()` 里给下载请求补上 `Referer`。
四个 `downloadFile` / `downloadFileWithStatus` 重载最终都汇到这一个函数，
所以只有一处构造请求的地方要改，**没有改动任何函数签名**。

Referer 取目标 URL 自己的源（`scheme://host[:port]/`），而不是把详情页地址一路传下来：

- 站点只校验同源，取源即可满足；
- 同一套写法对 `AppUpdateManager` / `DatabaseUpdateManager` 的 GitHub、Gitee
  下载同样成立，不用改它们的调用点；
- 只保留源、丢掉 path，也避免把下载 token 泄露给跳转目标。

推导逻辑单独拆成 public 静态方法 `NetworkManager::defaultRefererForUrl()`，以便写单元测试。

**经实测确认不受影响、因此没有改的部分：**

- 搜索页 `/?s=` 与详情页仍返回 200，href 仍是
  `href="https://flingtrainer.com/downloads/<token>,," class="attachment-link"`，
  `ModifierParser` 照旧能解析；`sendGetRequest()` 未改动。
- `/wp-content/uploads/**.jpg` 封面图没有防盗链，绕开 `NetworkManager`
  自己发请求的 `CoverExtractor` 不用动。
- `DownloadManager::cleanUrl()` 去掉结尾 `,,` 无害：带与不带，第 1 跳跳转结果完全一样。
- 第 3 跳支持 Range（206），`.crdownload` 断点续传这条路仍然成立。

## 怎么验证

- [x] `build.cmd tests`
- [x] 本地跑过相关界面 / 下载 / 搜索路径

以上两项由仓库作者在 Windows 本机执行并反馈通过。**AI 未自行构建或运行**：
`build.cmd` 需要 Windows，而改动是在 WSL 里完成的，该环境下 interop 起不来 `cmd.exe`。

新增的两个单元测试只覆盖 `defaultRefererForUrl()` 的推导（同源、保留非默认端口、
无 scheme/host 时返回空）。现有的 `TestDownloadRequestHandler` 测试桩在构造
`QNetworkRequest` **之前**就返回了，因此任何单元测试都无法证明这个请求头真的发上了网络 ——
这一点只能靠上面的实跑。断点续传与扩展名纠正这两个子项，作者未单独反馈结果。

## 检查项

- [x] 已阅读 [CONTRIBUTING.md](https://github.com/Sqhh99/FLiNG-Downloader/blob/main/CONTRIBUTING.md)
- [x] 若改动了翻译库、i18n、模型或打包资源，已在上文写明（本次均未改动）
- [x] AI 使用披露：是。上游行为的排查（curl 对照实验）、代码改动、单元测试与本记录均由
  Claude Code 生成；构建与下载实测由作者在 Windows 上完成。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV3JumD3tWiPwjAQF2e1sb
